### PR TITLE
LOOM-NOTQUITESOMANYVARARGS: Optimize property setter to not create a var...

### DIFF
--- a/sdk/src/system/Reflection/Type.ls
+++ b/sdk/src/system/Reflection/Type.ls
@@ -472,7 +472,7 @@ public native class Type extends MemberInfo {
             if(!method)
                 return false;
 
-            method.invoke(object, value);
+            method.invokeSingle(object, value);
             return true;
         }
 


### PR DESCRIPTION
... arg vector per set
