### PR TITLE
LOOM-DocGenFix: Doc generation crash fix. 

### DIFF
--- a/docs/lib/class_doc.rb
+++ b/docs/lib/class_doc.rb
@@ -224,6 +224,7 @@ class Module::ClassDoc
     return {} if data[:metainfo].nil?
     serialized_metainfo = {}
     data[:metainfo].each do |key, entries|
+      next if !key.is_a? String
       serialized_metainfo[key.downcase.to_sym] = []
       entries.each do |raw_entry|
         serialized_entry = {}


### PR DESCRIPTION
This is really just making sure it doesn't blow up if key is null / not a string. We should check why key gets a non-string value from the new metainfo.
