### PR TITLE
Fixed Rakefile to use the ANDROID_NDK environment variable instead of 'n...

### DIFF
--- a/README.android
+++ b/README.android
@@ -4,12 +4,14 @@ Requirements: NDK r8b+, Android SDK for API 10+
 
 1. In a terminal, export the location of your NDK installation in the ANDROID_NDK environment variable, for example: export ANDROID_NDK=~/Android/android-ndk-r8b
 
-2. Change directory to the Loom Native SDK and run: rake deploy:sdk
+2. In a terminal, set the location of your SDK installation's '/tools' folder in your PATH environment variable, for example: export PATH=$PATH:~/android-sdk-macosx/tools
 
-3. Change directory to your Loom project and run: 
+3. Change directory to the Loom Native SDK and run: rake deploy:sdk
+
+4. Change directory to your Loom project and run: 
 
 loom use dev (enter)
 loom run --android
 
-4. Your project should compile and run on the connected Android device
+5. Your project should compile and run on the connected Android device
 

--- a/Rakefile
+++ b/Rakefile
@@ -741,7 +741,7 @@ file 'build/luajit_android/lib/libluajit-5.1.a' do
     else
     puts "building LuaJIT Android on OSX / Linux"
       # OSX / LINUX
-      NDK = `which ndk-build`.split("/ndk-build")[0]
+      NDK = ENV['ANDROID_NDK']
       if (!NDK)
           raise "\n\nPlease ensure ndk-build from NDK rev 8b is on your path"
       end


### PR DESCRIPTION
...dk-build'. Updated README.android to include note on setting up the Android SDK /tools folder in your path.
