### PR TITLE
Set the rubyzip gem to need a version < 1.0.0 because of some error with...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rake'
+gem 'rubyzip'
 
 base_path = Pathname.new(File.dirname(__FILE__))
 relative_to_base = base_path.relative_path_from(Pathname.new(Dir.pwd))

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
       yajl-ruby (~> 1.1.0)
     rake (10.0.3)
     redcarpet (2.3.0)
+    rubyzip (1.0.0)
     yajl-ruby (1.1.0)
 
 PLATFORMS
@@ -21,3 +22,4 @@ DEPENDENCIES
   pygments.rb
   rake
   redcarpet (~> 2.3.0)
+  rubyzip

--- a/Rakefile
+++ b/Rakefile
@@ -1017,9 +1017,8 @@ def require_zip_dependencies!
   begin
     require 'rubygems'
     require 'zip'
-    # require 'zipfilesystem'
 	rescue LoadError
-    	puts "This Rakefile requires the latest rubyzip gem. Install it using: gem install rubyzip"
+    	puts "!!! Unable to require the RubyZip gem.  Please run 'bundle install'"
     	exit(1)
   end
 end


### PR DESCRIPTION
... the recently release 1.0.0 causing 'zip/zip' to not import properly.  Added require_zip_dependencies function to places where an inline, unsafely handled require 'zip/zip' was used.  Fixed incorrect android ndk error output message.
