### PR TITLE
Fixed 'preserveAspect' Boolean not being set properly for Texture2D.scal...

### DIFF
--- a/loom/graphics/gfxScript.cpp
+++ b/loom/graphics/gfxScript.cpp
@@ -262,6 +262,7 @@ static void scaleImageOnDisk(const char *outPath, const char *inPath, int outWid
     rn->inPath    = inPath;
     rn->outWidth  = outWidth;
     rn->outHeight = outHeight;
+    rn->preserveAspect = preserveAspect;
 
     loom_thread_start(scaleImageOnDisk_body, rn);
 }


### PR DESCRIPTION
...eImageOnDisk().
