### PR TITLE
Fix build errors on OSX 10.9

### DIFF
--- a/loom/graphics/internal/bgfx/include/glext/gl/glext.h
+++ b/loom/graphics/internal/bgfx/include/glext/gl/glext.h
@@ -5502,7 +5502,11 @@ typedef ptrdiff_t GLsizeiptrARB;
 #ifndef GL_ARB_shader_objects
 /* GL types for program/shader text and shader object handles */
 typedef char GLcharARB;
+#ifdef __APPLE__
+typedef void *GLhandleARB;
+#else
 typedef unsigned int GLhandleARB;
+#endif
 #endif
 
 /* GL type for "half" precision (s10e5) float data in host memory */

--- a/loom/vendor/geldreich/resampler.cpp
+++ b/loom/vendor/geldreich/resampler.cpp
@@ -38,7 +38,9 @@ static inline int resampler_range_check(int v, int h) { (void)h; resampler_asser
 
 #define RESAMPLER_DEBUG 0
 
+#ifndef M_PI
 #define M_PI 3.14159265358979323846
+#endif
 
 // Float to int cast with truncation.
 static inline int cast_to_int(Resample_Real i)


### PR DESCRIPTION
OSX defines GLhandleARB as void\* not unsigned int.
A better fix might be to upgrade all the gl headers to the latest
versions.
