### PR TITLE
LOOM-FIXCLIENT: Add a checker board texture when the texture notifications are currently disabled

### DIFF
--- a/loom/graphics/gfxTexture.h
+++ b/loom/graphics/gfxTexture.h
@@ -113,6 +113,8 @@ private:
         return id;
     }
 
+    static void loadCheckerBoard(TextureID id);
+
     static void initialize();
 
     static void handleAssetNotification(void *payload, const char *name);


### PR DESCRIPTION
Without this... any textures loaded while texture notifications are disabled will be invalid and will cause corruption
