### PR TITLE
Fixed Windows reg query for PROCESSOR_ARCHITECTURE to be more simple and...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -107,14 +107,24 @@ puts "*** Building with #{$numCores} cores."
 # Windows specific checks and settings
 if $LOOM_HOST_OS == 'windows'
   # This gets the true architecture of the machine, not the target architecture of the currently executing binary (that is what %PROCESSOR_ARCHITECTURE% returns)
-  WINDOWS_PROCARCH_BITS = `reg query "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Environment" /v PROCESSOR_ARCHITECTURE`.split("AMD")[1].split(" ")[0].split("\n")[0]
+  # Note: Original check of this seemed way over complicated; just default to 32 and then search for 64 instead! 
+  # => Valid values seem to only be "AMD64", "IA64", or "x86"
+  proc_arch = `reg query "HKLM\\System\\CurrentControlSet\\Control\\Session Manager\\Environment" /v PROCESSOR_ARCHITECTURE`
+  if proc_arch.empty? || proc_arch.index("64").nil?
+    WINDOWS_PROCARCH_BITS = "32"
+  else
+    WINDOWS_PROCARCH_BITS = "64"
+  end
+  
   # Is this a 32 or a 64 bit OS?
   if WINDOWS_PROCARCH_BITS == "64"
     puts "*** Windows x64"
+    puts "*** Detected 64 Bit Windows PROCESSOR_ARCHITECTURE: #{proc_arch}"
     WINDOWS_ISX64 = "1"
     WINDOWS_ANDROID_PREBUILT_DIR = "windows-x86_64"
   else
     puts "*** Windows x86"
+    puts "*** Detected 32 Bit Windows PROCESSOR_ARCHITECTURE: #{proc_arch}"
     WINDOWS_PROCARCH_BITS = "32"
     WINDOWS_ANDROID_PREBUILT_DIR = "windows"
   end
@@ -126,6 +136,8 @@ else
   WINDOWS_PROCARCH_BITS = "32"
   WINDOWS_ISX64 = "0"
   WINDOWS_ANDROID_PREBUILT_DIR = "windows"
+  puts "*** Non-Windows Platform"
+  puts "*** Defaulting to 32 Bit Windows PROCESSOR_ARCHITECTURE"
 end
 
 # Determine the APK name.

--- a/build/windowsBuildHelper.bat
+++ b/build/windowsBuildHelper.bat
@@ -9,7 +9,7 @@ IF EXIST "%programfiles%\Microsoft Visual Studio 10.0\VC" (
 )
 IF EXIST "%programfiles(x86)%\Microsoft Visual Studio 10.0\VC" (
   echo Registering Visual Studio 10.0 vars...
-  call "%programfiles%\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+  call "%programfiles(x86)%\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
   GOTO YAY
 )
 IF EXIST "%programfiles%\Microsoft Visual Studio 11.0\VC" (


### PR DESCRIPTION
... error proof (ie. removed potential null string ops).  Fixed missing (x86) inside of windowsBuildHelper.bat

NOTE: Tested on OSX Mavericks, Win AMD64 (Windows 8.1), and Win x86 (Windows 7) machines. Seems solid.
