### PR TITLE
Support for generating an MD5 of a String.  Added to the String class so...

### DIFF
--- a/loom/common/utils/md5.cpp
+++ b/loom/common/utils/md5.cpp
@@ -1,0 +1,362 @@
+/* MD5
+ converted to C++ class by Frank Thilo (thilo@unix-ag.org)
+ for bzflag (http://www.bzflag.org)
+
+   based on:
+
+   md5.h and md5.c
+   reference implemantion of RFC 1321
+
+   Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
+rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD5 Message-Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD5 Message-Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose. It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+
+*/
+
+/* interface header */
+#include "md5.h"
+
+/* system implementation headers */
+#include <stdio.h>
+
+
+// Constants for MD5Transform routine.
+#define S11 7
+#define S12 12
+#define S13 17
+#define S14 22
+#define S21 5
+#define S22 9
+#define S23 14
+#define S24 20
+#define S31 4
+#define S32 11
+#define S33 16
+#define S34 23
+#define S41 6
+#define S42 10
+#define S43 15
+#define S44 21
+
+///////////////////////////////////////////////
+
+// F, G, H and I are basic MD5 functions.
+inline MDFive::uint4 MDFive::MD5F(uint4 x, uint4 y, uint4 z) {
+  return x&y | ~x&z;
+}
+
+inline MDFive::uint4 MDFive::MD5G(uint4 x, uint4 y, uint4 z) {
+  return x&z | y&~z;
+}
+
+inline MDFive::uint4 MDFive::MD5H(uint4 x, uint4 y, uint4 z) {
+  return x^y^z;
+}
+
+inline MDFive::uint4 MDFive::MD5I(uint4 x, uint4 y, uint4 z) {
+  return y ^ (x | ~z);
+}
+
+// rotate_left rotates x left n bits.
+inline MDFive::uint4 MDFive::rotate_left(uint4 x, int n) {
+  return (x << n) | (x >> (32-n));
+}
+
+// FF, GG, HH, and II transformations for rounds 1, 2, 3, and 4.
+// Rotation is separate from addition to prevent recomputation.
+inline void MDFive::MD5FF(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+  a = rotate_left(a + MD5F(b,c,d) + x + ac, s) + b;
+}
+
+inline void MDFive::MD5GG(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+  a = rotate_left(a + MD5G(b,c,d) + x + ac, s) + b;
+}
+
+inline void MDFive::MD5HH(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+  a = rotate_left(a + MD5H(b,c,d) + x + ac, s) + b;
+}
+
+inline void MDFive::MD5II(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac) {
+  a = rotate_left(a + MD5I(b,c,d) + x + ac, s) + b;
+}
+
+//////////////////////////////////////////////
+
+// default ctor, just initailize
+MDFive::MDFive()
+{
+  init();
+}
+
+//////////////////////////////////////////////
+
+// nifty shortcut ctor, compute MD5 for string and finalize it right away
+MDFive::MDFive(const std::string &text)
+{
+  init();
+  update(text.c_str(), text.length());
+  finalize();
+}
+
+//////////////////////////////
+
+void MDFive::init()
+{
+  finalized=false;
+
+  count[0] = 0;
+  count[1] = 0;
+
+  // load magic initialization constants.
+  state[0] = 0x67452301;
+  state[1] = 0xefcdab89;
+  state[2] = 0x98badcfe;
+  state[3] = 0x10325476;
+}
+
+//////////////////////////////
+
+// decodes input (unsigned char) into output (uint4). Assumes len is a multiple of 4.
+void MDFive::decode(uint4 output[], const uint1 input[], size_type len)
+{
+  for (unsigned int i = 0, j = 0; j < len; i++, j += 4)
+    output[i] = ((uint4)input[j]) | (((uint4)input[j+1]) << 8) |
+      (((uint4)input[j+2]) << 16) | (((uint4)input[j+3]) << 24);
+}
+
+//////////////////////////////
+
+// encodes input (uint4) into output (unsigned char). Assumes len is
+// a multiple of 4.
+void MDFive::encode(uint1 output[], const uint4 input[], size_type len)
+{
+  for (size_type i = 0, j = 0; j < len; i++, j += 4) {
+    output[j] = input[i] & 0xff;
+    output[j+1] = (input[i] >> 8) & 0xff;
+    output[j+2] = (input[i] >> 16) & 0xff;
+    output[j+3] = (input[i] >> 24) & 0xff;
+  }
+}
+
+//////////////////////////////
+
+// apply MD5 algo on a block
+void MDFive::transform(const uint1 block[blocksize])
+{
+  uint4 a = state[0], b = state[1], c = state[2], d = state[3], x[16];
+  decode (x, block, blocksize);
+
+  /* Round 1 */
+  MD5FF(a, b, c, d, x[ 0], S11, 0xd76aa478); /* 1 */
+  MD5FF(d, a, b, c, x[ 1], S12, 0xe8c7b756); /* 2 */
+  MD5FF(c, d, a, b, x[ 2], S13, 0x242070db); /* 3 */
+  MD5FF(b, c, d, a, x[ 3], S14, 0xc1bdceee); /* 4 */
+  MD5FF(a, b, c, d, x[ 4], S11, 0xf57c0faf); /* 5 */
+  MD5FF(d, a, b, c, x[ 5], S12, 0x4787c62a); /* 6 */
+  MD5FF(c, d, a, b, x[ 6], S13, 0xa8304613); /* 7 */
+  MD5FF(b, c, d, a, x[ 7], S14, 0xfd469501); /* 8 */
+  MD5FF(a, b, c, d, x[ 8], S11, 0x698098d8); /* 9 */
+  MD5FF(d, a, b, c, x[ 9], S12, 0x8b44f7af); /* 10 */
+  MD5FF(c, d, a, b, x[10], S13, 0xffff5bb1); /* 11 */
+  MD5FF(b, c, d, a, x[11], S14, 0x895cd7be); /* 12 */
+  MD5FF(a, b, c, d, x[12], S11, 0x6b901122); /* 13 */
+  MD5FF(d, a, b, c, x[13], S12, 0xfd987193); /* 14 */
+  MD5FF(c, d, a, b, x[14], S13, 0xa679438e); /* 15 */
+  MD5FF(b, c, d, a, x[15], S14, 0x49b40821); /* 16 */
+
+  /* Round 2 */
+  MD5GG(a, b, c, d, x[ 1], S21, 0xf61e2562); /* 17 */
+  MD5GG(d, a, b, c, x[ 6], S22, 0xc040b340); /* 18 */
+  MD5GG(c, d, a, b, x[11], S23, 0x265e5a51); /* 19 */
+  MD5GG(b, c, d, a, x[ 0], S24, 0xe9b6c7aa); /* 20 */
+  MD5GG(a, b, c, d, x[ 5], S21, 0xd62f105d); /* 21 */
+  MD5GG(d, a, b, c, x[10], S22,  0x2441453); /* 22 */
+  MD5GG(c, d, a, b, x[15], S23, 0xd8a1e681); /* 23 */
+  MD5GG(b, c, d, a, x[ 4], S24, 0xe7d3fbc8); /* 24 */
+  MD5GG(a, b, c, d, x[ 9], S21, 0x21e1cde6); /* 25 */
+  MD5GG(d, a, b, c, x[14], S22, 0xc33707d6); /* 26 */
+  MD5GG(c, d, a, b, x[ 3], S23, 0xf4d50d87); /* 27 */
+  MD5GG(b, c, d, a, x[ 8], S24, 0x455a14ed); /* 28 */
+  MD5GG(a, b, c, d, x[13], S21, 0xa9e3e905); /* 29 */
+  MD5GG(d, a, b, c, x[ 2], S22, 0xfcefa3f8); /* 30 */
+  MD5GG(c, d, a, b, x[ 7], S23, 0x676f02d9); /* 31 */
+  MD5GG(b, c, d, a, x[12], S24, 0x8d2a4c8a); /* 32 */
+
+  /* Round 3 */
+  MD5HH(a, b, c, d, x[ 5], S31, 0xfffa3942); /* 33 */
+  MD5HH(d, a, b, c, x[ 8], S32, 0x8771f681); /* 34 */
+  MD5HH(c, d, a, b, x[11], S33, 0x6d9d6122); /* 35 */
+  MD5HH(b, c, d, a, x[14], S34, 0xfde5380c); /* 36 */
+  MD5HH(a, b, c, d, x[ 1], S31, 0xa4beea44); /* 37 */
+  MD5HH(d, a, b, c, x[ 4], S32, 0x4bdecfa9); /* 38 */
+  MD5HH(c, d, a, b, x[ 7], S33, 0xf6bb4b60); /* 39 */
+  MD5HH(b, c, d, a, x[10], S34, 0xbebfbc70); /* 40 */
+  MD5HH(a, b, c, d, x[13], S31, 0x289b7ec6); /* 41 */
+  MD5HH(d, a, b, c, x[ 0], S32, 0xeaa127fa); /* 42 */
+  MD5HH(c, d, a, b, x[ 3], S33, 0xd4ef3085); /* 43 */
+  MD5HH(b, c, d, a, x[ 6], S34,  0x4881d05); /* 44 */
+  MD5HH(a, b, c, d, x[ 9], S31, 0xd9d4d039); /* 45 */
+  MD5HH(d, a, b, c, x[12], S32, 0xe6db99e5); /* 46 */
+  MD5HH(c, d, a, b, x[15], S33, 0x1fa27cf8); /* 47 */
+  MD5HH(b, c, d, a, x[ 2], S34, 0xc4ac5665); /* 48 */
+
+  /* Round 4 */
+  MD5II(a, b, c, d, x[ 0], S41, 0xf4292244); /* 49 */
+  MD5II(d, a, b, c, x[ 7], S42, 0x432aff97); /* 50 */
+  MD5II(c, d, a, b, x[14], S43, 0xab9423a7); /* 51 */
+  MD5II(b, c, d, a, x[ 5], S44, 0xfc93a039); /* 52 */
+  MD5II(a, b, c, d, x[12], S41, 0x655b59c3); /* 53 */
+  MD5II(d, a, b, c, x[ 3], S42, 0x8f0ccc92); /* 54 */
+  MD5II(c, d, a, b, x[10], S43, 0xffeff47d); /* 55 */
+  MD5II(b, c, d, a, x[ 1], S44, 0x85845dd1); /* 56 */
+  MD5II(a, b, c, d, x[ 8], S41, 0x6fa87e4f); /* 57 */
+  MD5II(d, a, b, c, x[15], S42, 0xfe2ce6e0); /* 58 */
+  MD5II(c, d, a, b, x[ 6], S43, 0xa3014314); /* 59 */
+  MD5II(b, c, d, a, x[13], S44, 0x4e0811a1); /* 60 */
+  MD5II(a, b, c, d, x[ 4], S41, 0xf7537e82); /* 61 */
+  MD5II(d, a, b, c, x[11], S42, 0xbd3af235); /* 62 */
+  MD5II(c, d, a, b, x[ 2], S43, 0x2ad7d2bb); /* 63 */
+  MD5II(b, c, d, a, x[ 9], S44, 0xeb86d391); /* 64 */
+
+  state[0] += a;
+  state[1] += b;
+  state[2] += c;
+  state[3] += d;
+
+  // Zeroize sensitive information.
+  memset(x, 0, sizeof x);
+}
+
+//////////////////////////////
+
+// MD5 block update operation. Continues an MD5 message-digest
+// operation, processing another message block
+void MDFive::update(const unsigned char input[], size_type length)
+{
+  // compute number of bytes mod 64
+  size_type index = count[0] / 8 % blocksize;
+
+  // Update number of bits
+  if ((count[0] += (length << 3)) < (length << 3))
+    count[1]++;
+  count[1] += (length >> 29);
+
+  // number of bytes we need to fill in buffer
+  size_type firstpart = 64 - index;
+
+  size_type i;
+
+  // transform as many times as possible.
+  if (length >= firstpart)
+  {
+    // fill buffer first, transform
+    memcpy(&buffer[index], input, firstpart);
+    transform(buffer);
+
+    // transform chunks of blocksize (64 bytes)
+    for (i = firstpart; i + blocksize <= length; i += blocksize)
+      transform(&input[i]);
+
+    index = 0;
+  }
+  else
+    i = 0;
+
+  // buffer remaining input
+  memcpy(&buffer[index], &input[i], length-i);
+}
+
+//////////////////////////////
+
+// for convenience provide a verson with signed char
+void MDFive::update(const char input[], size_type length)
+{
+  update((const unsigned char*)input, length);
+}
+
+//////////////////////////////
+
+// MD5 finalization. Ends an MD5 message-digest operation, writing the
+// the message digest and zeroizing the context.
+MDFive& MDFive::finalize()
+{
+  static unsigned char padding[64] = {
+    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+  };
+
+  if (!finalized) {
+    // Save number of bits
+    unsigned char bits[8];
+    encode(bits, count, 8);
+
+    // pad out to 56 mod 64.
+    size_type index = count[0] / 8 % 64;
+    size_type padLen = (index < 56) ? (56 - index) : (120 - index);
+    update(padding, padLen);
+
+    // Append length (before padding)
+    update(bits, 8);
+
+    // Store state in digest
+    encode(digest, state, 16);
+
+    // Zeroize sensitive information.
+    memset(buffer, 0, sizeof buffer);
+    memset(count, 0, sizeof count);
+
+    finalized=true;
+  }
+
+  return *this;
+}
+
+//////////////////////////////
+
+// return hex representation of digest as string
+std::string MDFive::hexdigest() const
+{
+  if (!finalized)
+    return "";
+
+  char buf[33];
+  for (int i=0; i<16; i++)
+    sprintf(buf+i*2, "%02x", digest[i]);
+  buf[32]=0;
+
+  return std::string(buf);
+}
+
+//////////////////////////////
+
+std::ostream& operator<<(std::ostream& out, MDFive md5)
+{
+  return out << md5.hexdigest();
+}
+
+//////////////////////////////
+
+std::string mdfive(const std::string str)
+{
+    MDFive md5 = MDFive(str);
+
+    return md5.hexdigest();
+}

--- a/loom/common/utils/md5.h
+++ b/loom/common/utils/md5.h
@@ -1,0 +1,93 @@
+/* MD5
+ converted to C++ class by Frank Thilo (thilo@unix-ag.org)
+ for bzflag (http://www.bzflag.org)
+
+   based on:
+
+   md5.h and md5.c
+   reference implementation of RFC 1321
+
+   Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
+rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD5 Message-Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD5 Message-Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose. It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+
+*/
+
+#ifndef BZF_MD5_H
+#define BZF_MD5_H
+
+#include <string>
+#include <iostream>
+
+
+// a small class for calculating MD5 hashes of strings or byte arrays
+// it is not meant to be fast or secure
+//
+// usage: 1) feed it blocks of uchars with update()
+//      2) finalize()
+//      3) get hexdigest() string
+//      or
+//      MD5(std::string).hexdigest()
+//
+// assumes that char is 8 bit and int is 32 bit
+class MDFive
+{
+public:
+  typedef unsigned int size_type; // must be 32bit
+
+  MDFive();
+  MDFive(const std::string& text);
+  void update(const unsigned char *buf, size_type length);
+  void update(const char *buf, size_type length);
+  MDFive& finalize();
+  std::string hexdigest() const;
+  friend std::ostream& operator<<(std::ostream&, MDFive md5);
+
+private:
+  void init();
+  typedef unsigned char uint1; //  8bit
+  typedef unsigned int uint4;  // 32bit
+  enum {blocksize = 64}; // VC6 won't eat a const static int here
+
+  void transform(const uint1 block[blocksize]);
+  static void decode(uint4 output[], const uint1 input[], size_type len);
+  static void encode(uint1 output[], const uint4 input[], size_type len);
+
+  bool finalized;
+  uint1 buffer[blocksize]; // bytes that didn't fit in last 64 byte chunk
+  uint4 count[2];   // 64bit counter for number of bits (lo, hi)
+  uint4 state[4];   // digest so far
+  uint1 digest[16]; // the result
+
+  // low level logic operations
+  static inline uint4 MD5F(uint4 x, uint4 y, uint4 z);
+  static inline uint4 MD5G(uint4 x, uint4 y, uint4 z);
+  static inline uint4 MD5H(uint4 x, uint4 y, uint4 z);
+  static inline uint4 MD5I(uint4 x, uint4 y, uint4 z);
+  static inline uint4 rotate_left(uint4 x, int n);
+  static inline void MD5FF(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+  static inline void MD5GG(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+  static inline void MD5HH(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+  static inline void MD5II(uint4 &a, uint4 b, uint4 c, uint4 d, uint4 x, uint4 s, uint4 ac);
+};
+
+std::string mdfive(const std::string str);
+
+#endif

--- a/loom/script/native/core/system/lmString.cpp
+++ b/loom/script/native/core/system/lmString.cpp
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <cstring>
+#include "loom/common/utils/md5.h"
 #include "loom/common/core/allocator.h"
 #include "loom/script/loomscript.h"
 #include "loom/script/runtime/lsRuntime.h"
@@ -442,6 +443,22 @@ public:
         return 1;
     }
 
+    static int _toMD5(lua_State *L)
+    {
+        lmAssert(lua_isstring(L, 1), "Non-string passed to String._toMD5");
+
+        const char *svalue = lua_tostring(L, 1);
+
+        if (!svalue || !svalue[0])
+        {
+            lua_pushstring(L, "");
+            return 1;
+        }
+
+        lua_pushstring(L, mdfive(svalue).c_str());
+        return 1;
+    }    
+
     static int _find(lua_State *L)
     {
         lua_getglobal(L, "string");
@@ -601,6 +618,7 @@ static int registerSystemString(lua_State *L)
        .addStaticLuaFunction("_substring", &LSString::_substring)
        .addStaticLuaFunction("_toNumber", &LSString::_toNumber)
        .addStaticLuaFunction("_toBoolean", &LSString::_toBoolean)
+       .addStaticLuaFunction("_toMD5", &LSString::_toMD5)
        .addStaticLuaFunction("_find", &LSString::_find)
        .addStaticLuaFunction("_split", &LSString::_split)
        .addStaticLuaFunction("format", &LSString::format)

--- a/sdk/src/system/String.ls
+++ b/sdk/src/system/String.ls
@@ -138,19 +138,25 @@ package system {
     public native function slice(startIndex:Number = 0, endIndex:Number = 0x7fffffff):String;
     
     /**
-     *  Safetly evaluate the String to a Number value.
+     *  Safely evaluate the String to a Number value.
      *
      *  @return The Number value evaluated from the String
      */
     public native function toNumber():Number;
     
     /**
-     *  Safetly evaluate the String to a Boolean value.
+     *  Safely evaluate the String to a Boolean value.
      *
      *  @return The Boolean value evaluated from the String
      */
     public native function toBoolean():Boolean;
-
+    
+    /**
+     *  Safetly evaluate the String to an MD5 encoded string value.
+     *
+     *  @return The MD5 String value evaluated from the String
+     */
+    public native function toMD5():String;
     
     /**
      *  Splits a String object into an array of substrings by dividing it wherever the specified delimiter parameter occurs.
@@ -270,6 +276,7 @@ package system {
     private static native function _substring(value:String, startIndex:int = 0, endIndex:int = -1):String;
     private static native function _toNumber(value:String):Number;
     private static native function _toBoolean(value:String):Boolean;
+    private static native function _toMD5(value:String):String;
     private static native function _find(value:String, pattern:String):Vector.<String>;
     
     }


### PR DESCRIPTION
... that we don't have another brand new class just for this (only used with strings, so makes sense anyways).  Tested result with Google Hash and they match up.  md5 class added from Double Doodle as-is there.
