### PR TITLE
Fix iOS6 sincos crash

### DIFF
--- a/loom/vendor/stb/stb_vorbis.c
+++ b/loom/vendor/stb/stb_vorbis.c
@@ -1169,7 +1169,7 @@ static void sincos(float x, float *cosOut, float *sinOut)
     float sinTmp, cosTmp;
     
     // Apply wrapping.
-    x = fmod(x + 3.14159265f, 6.28318531f) -  3.14159265f;
+    x = (float)fmod(x + 3.14159265f, 6.28318531f) -  3.14159265f;
 
     //compute sine
     if (x < 0)


### PR DESCRIPTION
XCode likes to optimize use to use a sincos implementation that is not present in iOS 6, so we added a workaround to avoid the optimization.
