### PR TITLE
Proper early checking for failed Native Texture Asset loads to avoid orp...

### DIFF
--- a/loom/graphics/gfxTexture.cpp
+++ b/loom/graphics/gfxTexture.cpp
@@ -222,6 +222,14 @@ TextureInfo *Texture::initFromAssetManager(const char *path)
         return tinfo;
     }
 
+    // Force it to load.
+    if(loom_asset_lock(path, LATImage, 1) == NULL)
+    {
+        lmLog(gGFXTextureLogGroup, "Unable to lock the asset for texture %s", path);
+        return NULL;
+    }
+    loom_asset_unlock(path);
+
     // Get a new texture ID.
     TextureID id = getAvailableTextureID();
     if (id == TEXTUREINVALID)
@@ -235,10 +243,6 @@ TextureInfo *Texture::initFromAssetManager(const char *path)
     tinfo->handle.idx  = MARKEDTEXTURE;    // mark in use, but not yet loaded
     tinfo->texturePath = path;
     sTexturePathLookup.insert(path, id);
-
-    // Force it to load.
-    loom_asset_lock(path, LATImage, 1);
-    loom_asset_unlock(path);
 
     // allocate the texture handle/id
     lmLog(gGFXTextureLogGroup, "loading %s", path);

--- a/sdk/src/loom2d/Textures/Texture.ls
+++ b/sdk/src/loom2d/Textures/Texture.ls
@@ -142,7 +142,11 @@ package loom2d.textures
                 return assetPathCache[path];
 
             var textureInfo = Texture2D.initFromAsset(path);
-            Debug.assert(textureInfo, "Unable to load texture from asset: " + path);
+            if(textureInfo == null)
+            {
+                Console.print("WARNING: Unable to load texture from asset: " + path); 
+                return null;
+            }
 
             // And set up the concrete texture.
             var tex:ConcreteTexture = new ConcreteTexture(path, textureInfo.width, textureInfo.height);


### PR DESCRIPTION
...haned Native Texture IDs that break all the things
