### PR TITLE
Support for LongLong JSON reads (as Strings) to handle cases such as lar...

### DIFF
--- a/loom/script/native/core/system/lmJSON.cpp
+++ b/loom/script/native/core/system/lmJSON.cpp
@@ -160,8 +160,10 @@ public:
             return "";
         }
 
-        static char buffer[64];
-        memset(buffer, 0x00, 64);
+        //create static char buffer to return to Loomscript (it makes a copy of this, so it will not be overwritten)
+        //NOTE: the longest string length of an unsigned long long is 20 characters (0 to 18446744073709551615) + null terminator
+        static char buffer[32];
+        memset(buffer, 0x00, 32);
         unsigned long long val = (unsigned long long)json_integer_value(jllu);
         sprintf(buffer, "%llu", val);
 

--- a/sdk/src/system/JSON.ls
+++ b/sdk/src/system/JSON.ls
@@ -74,11 +74,10 @@ native class JSON {
     public native function getArrayJSONType(index:int):JSONType;
 
     /**
-     *  For very large integers that the platform does not reliably support,
-     *  (ie. Facebook user ids) this is a way to read those in as strings.
+     *  Gets a 64-bit long long integer as a String as LoomScript does not support 64-bit integers natively
      * 
      *  @param key String key mapped to the String value.
-     *  @return the String value mapped to the String key.
+     *  @return the 64-bit valuemapped to the String key, stored as a String.
      */
     public native function getLongLongAsString(key:String):String;
  


### PR DESCRIPTION
...ge integer IDs that are > 31bits in value (i.e.. Facebook User IDs)

NOTE: Code is direct from a Konrad Kiss implementation for DoubleDoodle in a branch of his there
