### PR TITLE
use .dup to not send frozen strings into method that modifies args

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,7 @@ $buildDocs = ENV['LOOM_BUILD_DOCS'] == "1" || ENV['LOOM_BUILD_DOCS'] == "true"
 ######################################
 
 def version_outdated?(current, required)
-  (Gem::Version.new(current) < Gem::Version.new(required))
+  (Gem::Version.new(current.dup) < Gem::Version.new(required.dup))
 end
 
 # Ruby version check.


### PR DESCRIPTION
`RUBY_VERSION` is a 'frozen' string, and apparently older versions of `Gem::Version` used `strip!` in its internals, so doing `Gem::Version.new(RUBY_VERSION)` implodes: https://github.com/rubygems/rubygems/commit/da4362a6644ca5a75c210677ac500bccfe75f529

but it should be safe to preventatively send in a copy of the string using `.dup`. so let's try that.
