### PR TITLE
Fix for compilation under VS2013 (jemalloc boolean fix)

### DIFF
--- a/loom/vendor/jemalloc-3.4.0/include/msvc_compat/stdbool.h
+++ b/loom/vendor/jemalloc-3.4.0/include/msvc_compat/stdbool.h
@@ -7,8 +7,13 @@
 
 /* MSVC doesn't define _Bool or bool in C, but does have BOOL */
 /* Note this doesn't pass autoconf's test because (bool) 0.5 != true */
+/* VS2013 (_MSC_VER 1800) already defines these */
+#if defined(_MSC_VER) && _MSC_VER < 1800
 typedef BOOL _Bool;
 #define bool _Bool
+#endif
+
+typedef int bool;
 #define true 1
 #define false 0
 


### PR DESCRIPTION
This should fix it for VS2013 and leave it as is for older versions.
