### PR TITLE
Fixed trace() strings being printed as the "format" printf argument

### DIFF
--- a/loom/script/native/core/system/lmConsole.cpp
+++ b/loom/script/native/core/system/lmConsole.cpp
@@ -85,7 +85,7 @@ int Console::print(lua_State *L)
     memcpy(buff, toprint.c_str(), length > 2000 ? 2000 : length);
 
     // print to log
-    LSLog(LSLogError, buff);
+    LSLog(LSLogError, "%s", buff);
 
     return 0;
 }


### PR DESCRIPTION
This fixes percent signs being stripped.
