### PR TITLE
add Dictionary.fetch() to retrieve a value with default

### DIFF
--- a/sdk/src/system/Dictionary.ls
+++ b/sdk/src/system/Dictionary.ls
@@ -93,6 +93,29 @@ final class Dictionary extends Object {
     public native function deleteKey(key:Object):void;
 
     /**
+     *  Returns the value for the given key if found in the dictionary, or else the default value.
+     *
+     *  @param key The key for the value to retrieve from the Dictionary.
+     *  @param defaultValue The value to return if the key is not found in the Dictionary. This may be a function that will accept the key and generate a value to return; its signature should be: function(key:Object):Object
+     *  @param thisObject Required if the defaultValue generator is an instance method and not a local or static function.
+     */
+    public function fetch(key:Object, defaultValue:Object, thisObject:Object = null):Object
+    {
+        var d:Dictionary.<Object, Object> = this;
+
+        if (!d[key])
+        {
+            if (defaultValue is Function)
+                return (defaultValue as Function).call(thisObject, key);
+
+            else
+                return defaultValue;
+        }
+
+        return d[key];
+    }
+
+    /**
      *  Assigns a Dictionary's values to the corresponding fields (if present) of a given Object.
      *
      *  @param dictionary A dictionary of String to Object pairs, to be applied to the given Object.

--- a/sdk/src/test/TestDictionary.ls
+++ b/sdk/src/test/TestDictionary.ls
@@ -365,7 +365,19 @@ class TestDictionary extends Test
         // Compiler Error
         //checkIndexError[100] = 100;
 
-    
+        // Fetch
+        var validKey = "validKey";
+        var defaultValue = "default";
+        var regularValue = "regular";
+        var generatedValue = "generated";
+
+        var dss = new Dictionary.<String, String>;
+        assert(dss.fetch(validKey, defaultValue) == defaultValue, "fetch on empty Dictionary should return default value");
+
+        dss[validKey] = regularValue;
+        assert(dss.fetch(validKey, defaultValue) == regularValue, "fetch on Dictionary with valid key should return associated value");
+        assert(dss.fetch("invalidKey", defaultValue) == defaultValue, "fetch on Dictionary with invalid key should return default value");
+        assert(dss.fetch("invalidKey", function(key:String):String{return generatedValue;}) == generatedValue, "fetch on Dictionary with invalid key should return generated value when default value is a function");
     }
     
     function TestDictionary()


### PR DESCRIPTION
This adds a convenience method to Dictionary that allows safe retrieval of values (no null checks):

``` as3
var value = dictionary.fetch(key, safety); // value is guaranteed to equal dictionary[key] or safety
```

The default value may be a function, in which case it will be called to generate the default value when needed.
