### PR TITLE
simplify rectangle separation test to improve performance

### DIFF
--- a/sdk/src/loom2d/Math/Rectangle.ls
+++ b/sdk/src/loom2d/Math/Rectangle.ls
@@ -66,14 +66,10 @@ package loom2d.math
          */
         public static function intersects(rect1:Rectangle, rect2:Rectangle):Boolean
         {
-            var left:Number   = Math.max2(rect1.x, rect2.x);
-            var right:Number  = Math.min2(rect1.x + rect1.width, rect2.x + rect2.width);
-            var top:Number    = Math.max2(rect1.y, rect2.y);
-            var bottom:Number = Math.min2(rect1.y + rect1.height, rect2.y + rect2.height);
-
-            if (left > right || top > bottom)
-                return false;
-
+            if (rect1.right < rect2.left) return false; // 1 is left of 2
+            if (rect1.left > rect2.right) return false; // 1 is right of 2
+            if (rect1.bottom < rect2.top) return false; // 1 is above 2
+            if (rect1.top > rect2.bottom) return false; // 1 is below 2
             return true;
         }        
     }


### PR DESCRIPTION
i've put together ad hoc tests to ensure the intersects method is still functioning as expected, and they [show speed ups of about 28%](https://github.com/LoomSDK/LoomSDK/commit/7012e6b#commitcomment-7861575):

* [baseline](https://github.com/ellemenno/LoomSDK/tree/PBG-rect-intersect-baseline/tests/RectangleIntersectsTest)
* [improved](https://github.com/ellemenno/LoomSDK/tree/PBG-rect-intersect-sat/tests/RectangleIntersectsTest)

..but i haven't been able to figure out how to get the loomlibs rejiggered to allow proper unit testing:
http://loomsdk.com/forums/feedback/topics/unittest-framework-for-loomscript/posts/5230