### PR TITLE
Fixed reload when a file gets added and deleted in rapid succession

### DIFF
--- a/tools/assetAgent/src/main.cpp
+++ b/tools/assetAgent/src/main.cpp
@@ -547,7 +547,6 @@ static void processFileEntryDeltas(utArray<FileEntryDelta> *deltas)
 
         if (canonicalFile[0] == 0)
         {
-            lmLog(gAssetAgentLogGroup, "   o Skipping due to not being in the asset folder!");
             lmLog(gAssetAgentLogGroup, "   o Ignoring file missing from the asset folder!");
 
             // Remove from the pending list.

--- a/tools/assetAgent/src/main.cpp
+++ b/tools/assetAgent/src/main.cpp
@@ -548,6 +548,12 @@ static void processFileEntryDeltas(utArray<FileEntryDelta> *deltas)
         if (canonicalFile[0] == 0)
         {
             lmLog(gAssetAgentLogGroup, "   o Skipping due to not being in the asset folder!");
+            lmLog(gAssetAgentLogGroup, "   o Ignoring file missing from the asset folder!");
+
+            // Remove from the pending list.
+            gPendingModifications.erase(i);
+            i--;
+            
             continue;
         }
 


### PR DESCRIPTION
If a file gets created and deleted very quickly, the live reloading asset system can pick up the creation, but then spams the console output when it can't find it anymore, since it was deleted.

This can happen very quickly when exporting with Audacity, since it creates and deletes a file named [filename]0.ogg before moving/deleting it, making the console continuously output the following, since the file doesn't get removed from the pending files list.

```
[loom.asset]    o Skipping due to not being in the asset folder!
[loom.asset] Failed to resolve path .\assets/laser0.ogg via realpath due to No such file or directory
[loom.asset]    o Skipping due to not being in the asset folder!
[loom.asset] Failed to resolve path .\assets/laser0.ogg via realpath due to No such file or directory
[loom.asset]    o Skipping due to not being in the asset folder!
[loom.asset] Failed to resolve path .\assets/laser0.ogg via realpath due to No such file or directory
[loom.asset]    o Skipping due to not being in the asset folder!
[loom.asset] Failed to resolve path .\assets/laser0.ogg via realpath due to No such file or directory
[loom.asset]    o Skipping due to not being in the asset folder!
[loom.asset] Failed to resolve path .\assets/laser0.ogg via realpath due to No such file or directory
```

I fixed this by removing the file from pending files if it doesn't exist, I don't think there are any negative side effects of this, but I might be mistaken.