### PR TITLE
Fixed sounds not being unloaded on code reload, now sounds are destroyed

### DIFF
--- a/loom/engine/bindings/loom/lmApplication.cpp
+++ b/loom/engine/bindings/loom/lmApplication.cpp
@@ -70,6 +70,7 @@ void loom_appShutdown(void)
     LoomApplication::shutdown();
 }
 
+extern void loomsound_reset();
 
 // container for external package functions
 typedef void (*FunctionRegisterPackage)(void);
@@ -200,6 +201,8 @@ void LoomApplication::reloadMainAssembly()
     platform_webViewDestroyAll();
     // cleanup ads
     platform_adMobDestroyAll();
+
+    loomsound_reset();
 
     const NativeDelegate *onReload = rootVM->getOnReloadDelegate();
     onReload->invoke();

--- a/loom/engine/sound/lsSound.cpp
+++ b/loom/engine/sound/lsSound.cpp
@@ -218,6 +218,16 @@ public:
     int playCount;
     char *path;
 
+    static void reset()
+    {
+        // Now restart all the sources after assigning the new buffer.
+        while (Sound::smList)
+        {
+            lmLog(gLoomSoundLogGroup, "Deleting sound...");
+            delete Sound::smList;
+        }
+    }
+
     static void preload(const char *assetPath)
     {
         OALBufferManager::getBufferForAsset(assetPath);
@@ -477,6 +487,13 @@ public:
         return playCount != 0;
     }
 };
+
+extern "C" {
+    void loomsound_reset()
+    {
+        Sound::reset();
+    }
+}
 
 Sound *Sound::smList = NULL;
 int Sound::count = 0;


### PR DESCRIPTION
This prevents sounds bleeding into the next reload and fixed background soundtrack stacking of sounds (super annoying).