### PR TITLE
Ouya build on Windows + Windows Compile fix w/VS2013 + CMake 3.0.1

### DIFF
--- a/application/ouya/src/co/theengine/loomdemo/LoomDemo.java
+++ b/application/ouya/src/co/theengine/loomdemo/LoomDemo.java
@@ -70,7 +70,7 @@ public class LoomDemo extends Cocos2dxActivity{
 		
         if(type.equals("cameraRequest"))
 		{
-            logError("Camera not supported on OUYA.");
+            Log.e("Loom", "Camera not supported on OUYA.");
 		}
 	}
 
@@ -132,13 +132,13 @@ public class LoomDemo extends Cocos2dxActivity{
         // Thanks to http://stackoverflow.com/questions/2150078/how-to-check-visibility-of-software-keyboard-in-android
         final View activityRootView = framelayout;
         Log.d("Loom", "Registering for global layout listener!");
-        logError("keyboardResize BUTTS");
+        Log.e("Loom", "keyboardResize BUTTS");
         activityRootView.getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() 
         {
             @Override
             public void onGlobalLayout() 
             {
-                logError("keyboardResize " + activityRootView.getHeight());
+                Log.e("Loom", "keyboardResize " + activityRootView.getHeight());
                 Log.d("Loom", "keyboardResize " + activityRootView.getHeight());
 
                 // Convert the dps to pixels
@@ -148,7 +148,7 @@ public class LoomDemo extends Cocos2dxActivity{
                 if (heightDiff > scaledThreshold)
                 {
                     // if more than 100 points, its probably a keyboard...
-                    logError("keyboardResize " + activityRootView.getHeight());
+                    Log.e("Loom", "keyboardResize " + activityRootView.getHeight());
                     triggerGenericEvent("keyboardResize", "" + activityRootView.getHeight());
                 }
              }
@@ -184,12 +184,6 @@ public class LoomDemo extends Cocos2dxActivity{
          ConfigurationInfo info = am.getDeviceConfigurationInfo();
          return (info.reqGlEsVersion >= 0x20000);
      }
-
-	public static native void log(String message);
-	public static native void logWarn(String message);
-	public static native void logError(String message);
-	public static native void logDebug(String message);
-	public static void logInfo(String message) { log(message); }
 
 	static 
 	{

--- a/loom/common/platform/platformAndroidJni.cpp
+++ b/loom/common/platform/platformAndroidJni.cpp
@@ -206,6 +206,42 @@ static utString jstring2string_(jstring jstr)
     return ret;
 }
 
+
+// Expose lmLog* to Java
+void Java_co_theengine_loomdemo_LoomDemo_log(JNIEnv *env, jobject thiz, jstring message)
+{
+    const char *messageString = env->GetStringUTFChars(message, 0);
+
+    lmLog(jniLogGroup, "%s", messageString);
+    env->ReleaseStringUTFChars(message, messageString);
+}
+
+
+void Java_co_theengine_loomdemo_LoomDemo_logWarn(JNIEnv *env, jobject thiz, jstring message)
+{
+    const char *messageString = env->GetStringUTFChars(message, 0);
+
+    lmLogWarn(jniLogGroup, "%s", messageString);
+    env->ReleaseStringUTFChars(message, messageString);
+}
+
+
+void Java_co_theengine_loomdemo_LoomDemo_logError(JNIEnv *env, jobject thiz, jstring message)
+{
+    const char *messageString = env->GetStringUTFChars(message, 0);
+
+    lmLogError(jniLogGroup, "%s", messageString);
+    env->ReleaseStringUTFChars(message, messageString);
+}
+
+
+void Java_co_theengine_loomdemo_LoomDemo_logDebug(JNIEnv *env, jobject thiz, jstring message)
+{
+    const char *messageString = env->GetStringUTFChars(message, 0);
+
+    lmLogDebug(jniLogGroup, "%s", messageString);
+    env->ReleaseStringUTFChars(message, messageString);
+}
 }
 
 JavaVM *LoomJni::m_psJavaVM = NULL;

--- a/loom/common/platform/platformAndroidJni.cpp
+++ b/loom/common/platform/platformAndroidJni.cpp
@@ -206,42 +206,6 @@ static utString jstring2string_(jstring jstr)
     return ret;
 }
 
-
-// Expose lmLog* to Java
-void Java_co_theengine_loomdemo_LoomDemo_log(JNIEnv *env, jobject thiz, jstring message)
-{
-    const char *messageString = env->GetStringUTFChars(message, 0);
-
-    lmLog(jniLogGroup, "%s", messageString);
-    env->ReleaseStringUTFChars(message, messageString);
-}
-
-
-void Java_co_theengine_loomdemo_LoomDemo_logWarn(JNIEnv *env, jobject thiz, jstring message)
-{
-    const char *messageString = env->GetStringUTFChars(message, 0);
-
-    lmLogWarn(jniLogGroup, "%s", messageString);
-    env->ReleaseStringUTFChars(message, messageString);
-}
-
-
-void Java_co_theengine_loomdemo_LoomDemo_logError(JNIEnv *env, jobject thiz, jstring message)
-{
-    const char *messageString = env->GetStringUTFChars(message, 0);
-
-    lmLogError(jniLogGroup, "%s", messageString);
-    env->ReleaseStringUTFChars(message, messageString);
-}
-
-
-void Java_co_theengine_loomdemo_LoomDemo_logDebug(JNIEnv *env, jobject thiz, jstring message)
-{
-    const char *messageString = env->GetStringUTFChars(message, 0);
-
-    lmLogDebug(jniLogGroup, "%s", messageString);
-    env->ReleaseStringUTFChars(message, messageString);
-}
 }
 
 JavaVM *LoomJni::m_psJavaVM = NULL;

--- a/loom/common/platform/platformNetwork.c
+++ b/loom/common/platform/platformNetwork.c
@@ -25,6 +25,9 @@
 #include "loom/common/core/assert.h"
 
 #if LOOM_PLATFORM == LOOM_PLATFORM_WIN32
+
+#define _WINSOCK_DEPRECATED_NO_WARNINGS 
+
 #include <WinSock2.h>
 #include <WS2tcpip.h>
 #include <WS2def.h>


### PR DESCRIPTION
Removed warning in platformNetwork.c
OUYA now builds on Windows
Reinstated methods in platformAndroidJni.cpp relied upon by Ouya