### PR TITLE
Added method info count and retrieval by index

### DIFF
--- a/docs/examples/RobotLegs/src/org/robotlegs/base/CommandMap.ls
+++ b/docs/examples/RobotLegs/src/org/robotlegs/base/CommandMap.ls
@@ -181,7 +181,7 @@ package org.robotlegs.base
 				injector.unmap(payloadClass, named);
 			}
 			
-			command.getType().getMethodInfo("execute").invoke(command, null);
+			command.getType().getMethodInfoByName("execute").invoke(command, null);
 		}
 		
 		/**
@@ -215,7 +215,7 @@ package org.robotlegs.base
 		{
 			if (!verifiedCommandClasses[commandClass])
 			{
-				if(commandClass.getType().getMethodInfo("execute") != null)
+				if(commandClass.getType().getMethodInfoByName("execute") != null)
 					verifiedCommandClasses[commandClass] = 1;
 
 				if (!verifiedCommandClasses[commandClass])

--- a/loom/script/native/core/system/Reflection/lmType.cpp
+++ b/loom/script/native/core/system/Reflection/lmType.cpp
@@ -109,15 +109,17 @@ static int registerSystemReflectionType(lua_State *L)
        .addMethod("getFieldInfoCount", &Type::getFieldInfoCount)
        .addMethod("getFieldInfo", &Type::getFieldInfo)
 
-       .addMethod("getPropertyInfoCount", &Type::getPropertyInfoCount)
-
+       .addMethod("getMethodInfoCount", &Type::getMethodInfoCount)
        .addMethod("getMethodInfo", &Type::getMethodInfo)
+
+       .addMethod("getPropertyInfoCount", &Type::getPropertyInfoCount)
        .addMethod("getPropertyInfo", &Type::getPropertyInfo)
 
        .addMethod("getConstructor", &Type::getConstructor)
 
-       .addMethod("getPropertyInfoByName", &Type::findPropertyInfoByName)
        .addMethod("getFieldInfoByName", &Type::findFieldInfoByName)
+       .addMethod("getPropertyInfoByName", &Type::findPropertyInfoByName)
+       .addMethod("getMethodInfoByName", &Type::findMethodInfoByName)
 
        .endClass()
 

--- a/loom/script/reflection/lsAssembly.cpp
+++ b/loom/script/reflection/lsAssembly.cpp
@@ -269,7 +269,7 @@ void Assembly::connectToDebugger(const char *host, int port)
         LSError("Unable to get system.debugger.DebuggerClient");
     }
 
-    MethodInfo *method = debuggerClient->getMethodInfo("connect");
+    MethodInfo *method = debuggerClient->findMethodInfoByName("connect");
 
     if (!method)
     {

--- a/loom/script/reflection/lsType.cpp
+++ b/loom/script/reflection/lsType.cpp
@@ -472,7 +472,45 @@ FieldInfo *Type::getFieldInfo(int index)
 }
 
 
-MethodInfo *Type::getMethodInfo(const utString& name)
+
+
+MethodInfo *Type::getMethodInfo(int index)
+{
+    if (methodMembersValid == false)
+    {
+        MemberTypes types;
+        types.method = true;
+        findMembers(types, methodMembers, true);
+        methodMembersValid = true;
+    }
+
+    if ((index < 0) || (index >= (int)methodMembers.size()))
+    {
+        LSError("Bad method info index");
+    }
+
+    return (MethodInfo *)methodMembers[index];
+}
+
+int Type::getMethodInfoCount()
+{
+    // Cache the result.
+    if (methodInfoCount != -1)
+    {
+        return methodInfoCount;
+    }
+
+    MemberTypes types;
+    types.method = true;
+    utArray<MemberInfo *> members;
+
+    findMembers(types, members, true);
+
+    methodInfoCount = (int)members.size();
+    return methodInfoCount;
+}
+
+MethodInfo *Type::findMethodInfoByName(const utString& name)
 {
     MemberInfo *minfo = findMember(name.c_str());
 

--- a/loom/script/reflection/lsType.h
+++ b/loom/script/reflection/lsType.h
@@ -117,9 +117,11 @@ private:
     int propertyInfoCount;
 
     bool fieldMembersValid;
+    bool methodMembersValid;
     bool propertyMembersValid;
 
     utArray<MemberInfo *> fieldMembers;
+    utArray<MemberInfo *> methodMembers;
     utArray<MemberInfo *> propertyMembers;
 
     void addMember(MemberInfo *member);
@@ -137,7 +139,7 @@ public:
         delegateReturnType(NULL),
         bcStaticInitializer(NULL), bcInstanceInitializer(NULL),
         fieldInfoCount(-1), methodInfoCount(-1), propertyInfoCount(-1),
-        fieldMembersValid(false), propertyMembersValid(false),
+        fieldMembersValid(false), methodMembersValid(false), propertyMembersValid(false),
         cached(false), maxMemberOrdinal(0), memberInfoOrdinalLookup(NULL)
     {
     }
@@ -173,12 +175,17 @@ public:
     int getFieldInfoCount();
     FieldInfo *getFieldInfo(int index);
 
+    int getMethodInfoCount();
+    MethodInfo *getMethodInfo(int index);
+
     int getPropertyInfoCount();
     PropertyInfo *getPropertyInfo(int index);
-
+    
     MemberInfo *findMember(const char *name, bool includeBases = true);
 
     FieldInfo *findFieldInfoByName(const char *name);
+
+    MethodInfo *findMethodInfoByName(const utString& name);
 
     PropertyInfo *findPropertyInfoByName(const char *name);
 
@@ -638,8 +645,6 @@ public:
     }
 
     Type *castToType(Type *to, bool tryReverse = false);
-
-    MethodInfo *getMethodInfo(const utString& name);
 
     void assignOrdinals();
 

--- a/sdk/src/system/Reflection/Type.ls
+++ b/sdk/src/system/Reflection/Type.ls
@@ -337,21 +337,28 @@ public native class Type extends MemberInfo {
     /**
      *  Gets the Assembly that the Type belongs to.
      *
-     *  @return The Type%s Assembly.
+     *  @return The Type's Assembly.
      */
     public native function getAssembly():Assembly;
     
     /**
-     *  Gets the number of FieldInfo%s associated with the Type and its inherited Fields.
+     *  Gets the number of FieldInfo's associated with the Type and its inherited Fields.
      *
-     *  @return Number of FieldInfo%s in the Type.
+     *  @return Number of FieldInfo's in the Type.
      */
     public native function getFieldInfoCount():int;
+    
+    /**
+     *  Gets the number of MethodInfo's associated with the Type and its inherited Methods.
+     *
+     *  @return Number of MethodInfo's in the Type.
+     */
+    public native function getMethodInfoCount():int;
 
     /**
-     *  Gets the number of PropertyInfo%s associated with the Type and its inherited Properties.
+     *  Gets the number of PropertyInfo's associated with the Type and its inherited Properties.
      *
-     *  @return Number of PropertyInfo%s in the Type.
+     *  @return Number of PropertyInfo's in the Type.
      */
     public native function getPropertyInfoCount():int;
     
@@ -362,14 +369,14 @@ public native class Type extends MemberInfo {
      *  @return Instance of the associated FieldInfo.
      */
     public native function getFieldInfo(index:int):FieldInfo;
-
+    
     /**
-     *  Gets the MethodInfo associated with the specified name.
+     *  Gets the MethodInfo associated with the specified index.
      *
-     *  @param name Name of the MethodInfo.
-     *  @return Instance of the associated FieldInfo, null if the method name does not exist.
+     *  @param index Index of associated MethodInfo.
+     *  @return Instance of the associated MethodInfo.
      */
-    public native function getMethodInfo(name:String):MethodInfo;
+    public native function getMethodInfo(index:int):MethodInfo;
 
     /**
      *  Gets the PropertyInfo associated with the specified index.
@@ -386,6 +393,14 @@ public native class Type extends MemberInfo {
      *  @return FieldInfo that matches to the name, null if the FieldInfo does not exist.
      */
     public native function getFieldInfoByName(name:String):FieldInfo;
+
+    /**
+     *  Gets the MethodInfo associated with the specified name.
+     *
+     *  @param name Name of the MethodInfo.
+     *  @return Instance of the associated FieldInfo, null if the method name does not exist.
+     */
+    public native function getMethodInfoByName(name:String):MethodInfo;
 
     /**
      *  Gets a PropertyInfo by its name.

--- a/sdk/src/test/TestReflection.ls
+++ b/sdk/src/test/TestReflection.ls
@@ -122,10 +122,10 @@ class TestReflection extends Test
         log(stype.getFullName());
         log(stype.getName());
         
-        var minfo:MethodInfo = stype.getMethodInfo("someMethod");
-        var sinfo:MethodInfo = stype.getMethodInfo("someStaticMethod");
+        var minfo:MethodInfo = stype.getMethodInfoByName("someMethod");
+        var sinfo:MethodInfo = stype.getMethodInfoByName("someStaticMethod");
         
-        var method = stype.getMethodInfo("someMethod");
+        var method = stype.getMethodInfoByName("someMethod");
         for (i = 0; i < method.getNumParameters(); i++) {
             var param = method.getParameter(i);
             log(param.getName() + " : " + param.getParameterType().getFullName());
@@ -133,13 +133,13 @@ class TestReflection extends Test
         
         var constructor = stype.getConstructor();
         
-        stype.getMethodInfo("someStaticMethodNoArgs").invoke(null);
+        stype.getMethodInfoByName("someStaticMethodNoArgs").invoke(null);
         sinfo.invoke(null, "Hey!", "7331");
         
         var c:ReflectClass = constructor.invoke() as ReflectClass;
         minfo.invoke(c, "Josh!", 1337);
         
-        stype.getMethodInfo("someMethodNoArgs").invoke(c);
+        stype.getMethodInfoByName("someMethodNoArgs").invoke(c);
         
         type = c.getType();
         


### PR DESCRIPTION
This changes the `getMethodInfo` signature and semantics, the new name is `getMethodInfoByName` which is now consistent with other methods.