### PR TITLE
Fixed LoomDemo to allow argument passing and console on Windows to work.

### DIFF
--- a/loom/engine/bindings/loom/lmApplication.cpp
+++ b/loom/engine/bindings/loom/lmApplication.cpp
@@ -44,6 +44,8 @@ using namespace LS;
 
 #include "loom/common/config/applicationConfig.h"
 
+#include "loom/script/native/core/system/lmProcess.h"
+
 LSLuaState     *LoomApplication::rootVM      = NULL;
 bool           LoomApplication::reloadQueued = false;
 bool           LoomApplication::suppressAssetTriggeredReload = false;
@@ -59,6 +61,9 @@ lmDefineLogGroup(scriptLogGroup, "loom.script", 1, LoomLogInfo);
 
 // Define the global Loom C entrypoints.
 extern "C" {
+
+extern void loomsound_shutdown();
+
 void loom_appSetup(void)
 {
     LoomApplication::initializeCoreServices();
@@ -355,9 +360,10 @@ int LoomApplication::initializeCoreServices()
     return 0;
 }
 
-
 void LoomApplication::shutdown()
 {
+    loomsound_shutdown();
+
     platform_HTTPCleanup();
 
     // Shut down application subsystems.

--- a/loom/script/native/core/system/lmProcess.h
+++ b/loom/script/native/core/system/lmProcess.h
@@ -1,0 +1,33 @@
+/*
+ * ===========================================================================
+ * Loom SDK
+ * Copyright 2011, 2012, 2013
+ * The Game Engine Company, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================
+ */
+
+#ifndef _lmprocess_h
+#define _lmprocess_h
+
+namespace LS {
+    class Process {
+    public:
+        static bool consoleAttached;
+        static void cleanupConsole();
+        static void _exit(int exitCode);
+    };
+}
+
+#endif

--- a/loom/vendor/openal-soft/Alc/ALc.c
+++ b/loom/vendor/openal-soft/Alc/ALc.c
@@ -2859,6 +2859,9 @@ static void ReleaseALC(void)
         do {
             num++;
         } while((dev=dev->next) != NULL);
+        // Disabled warning on force quit (leaving open devices)
+        // Otherwise the message interferes with console handling
+        // on Windows.
         //ERR("%u device%s not closed\n", num, (num>1)?"s":"");
     }
 }

--- a/loom/vendor/openal-soft/Alc/ALc.c
+++ b/loom/vendor/openal-soft/Alc/ALc.c
@@ -2859,7 +2859,7 @@ static void ReleaseALC(void)
         do {
             num++;
         } while((dev=dev->next) != NULL);
-        ERR("%u device%s not closed\n", num, (num>1)?"s":"");
+        //ERR("%u device%s not closed\n", num, (num>1)?"s":"");
     }
 }
 


### PR DESCRIPTION
Included are also fixes for shutdown cleanup, better support for direct LoomDemo execution with console on Windows and removal of OpenAL message complaining about having to cleanup resources on shutdown.