### PR TITLE
LuaBridge debug?

### DIFF
--- a/loom/script/native/lsLuaBridge.h
+++ b/loom/script/native/lsLuaBridge.h
@@ -49,7 +49,7 @@
 #define LUABRIDGE_LUABRIDGE_HEADER
 
 // undef to increase performance
-#define LUABRIDGE_DEBUG
+//#define LUABRIDGE_DEBUG
 
 #include "loom/script/common/lsError.h"
 #include "loom/script/runtime/lsLua.h"


### PR DESCRIPTION
This probably needs an ifdef on a global debug flag or something, but we probably shouldn't ship with it defined?

I don't know what are the implications of having it turned on/off, but I'm opening a PR to track it.