### PR TITLE
Fixes default clipping issues (popped up in FeathersComponentExplorer)

### DIFF
--- a/loom/engine/loom2d/l2dDisplayObjectContainer.cpp
+++ b/loom/engine/loom2d/l2dDisplayObjectContainer.cpp
@@ -112,7 +112,7 @@ void DisplayObjectContainer::renderChildren(lua_State *L)
     }
 
     // Is there a cliprect? If so, set it.
-    if ((clipX != 0) || (clipY != 0) || (clipWidth != 0) || (clipHeight != 0))
+    if (clipWidth != -1 && clipHeight != -1)
     {
         GFX::QuadRenderer::submit();
 

--- a/loom/engine/loom2d/l2dDisplayObjectContainer.h
+++ b/loom/engine/loom2d/l2dDisplayObjectContainer.h
@@ -42,7 +42,8 @@ public:
         type       = typeDisplayObjectContainer;
         _depthSort = false;
         _view      = 0;
-        clipX      = clipY = clipWidth = clipHeight = 0;
+        clipX      = clipY = 0;
+        clipWidth  = clipHeight = -1;
     }
 
     bool _depthSort;

--- a/loom/graphics/gfxVectorRenderer.cpp
+++ b/loom/graphics/gfxVectorRenderer.cpp
@@ -98,14 +98,6 @@ void VectorRenderer::setSize(int width, int height) {
 
 void VectorRenderer::beginFrame()
 {
-
-    Graphics::context()->glEnable(GL_STENCIL_TEST);
-    Graphics::context()->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    Graphics::context()->glEnable(GL_BLEND);
-    Graphics::context()->glEnable(GL_CULL_FACE);
-    Graphics::context()->glDisable(GL_DEPTH_TEST);
-
-
     nvgBeginFrame(nvg, frameWidth, frameHeight, 1);
 
 
@@ -148,7 +140,6 @@ void VectorRenderer::postDraw() {
 
 void VectorRenderer::endFrame()
 {
-    Graphics::context()->glEnable(GL_DEPTH_TEST);
 
 	/*
 	nvgBeginPath(nvg);


### PR DESCRIPTION
 ... and additionally removed unnecessary OpenGL state modification breaking stuff when an empty Shape was added to the stage