### PR TITLE
Screen Navigator Fix

### DIFF
--- a/sdk/src/feathers/controls/ScreenNavigator.ls
+++ b/sdk/src/feathers/controls/ScreenNavigator.ls
@@ -497,7 +497,7 @@ package feathers.controls
          */
         public function getScreen(id:String):ScreenNavigatorItem
         {
-            if(this._screens[id] == null)
+            if(this._screens[id] != null)
             {
                 return ScreenNavigatorItem(this._screens[id]);
             }


### PR DESCRIPTION
Bug Fixed:
- Fixed a backwards logical assessment that would cause null to be
  returned when getScreen is called with a valid ID, and cause a crash
  when getScreen is called with an invalid ID