### PR TITLE
Added profiler zero stack check

### DIFF
--- a/loom/common/core/performance.cpp
+++ b/loom/common/core/performance.cpp
@@ -26,7 +26,11 @@
 
 loom_allocator_t *gProfilerAllocator = NULL;
 
-// Uncomment for better stack imbalance error reporting
+// Enable the profiler from the start of execution. Enable this if you
+// want to profile application startup or are tracking down profiler stack
+// mismatch issues - when the profiler is enabled LOOM_PROFILE_START and
+// LOOM_PROFILE_END are checked to make sure an END is called for every
+// START.
 //#define LOOM_PROFILE_AT_ENGINE_START 1
 
 #ifndef NPERFORMANCE

--- a/loom/common/core/performance.cpp
+++ b/loom/common/core/performance.cpp
@@ -543,6 +543,9 @@ void LoomProfiler::hashZeroCheck()
 {
     if (mStackDepth != 0)
     {
+        // If you get this assert, it means you probably have mismatched LOOM_PROFILE_START
+        // and LOOM_PROFILE_END blocks. Enable LOOM_PROFILE_AT_ENGINE_START (see #define at top
+        // of file) to get a breakpoint on the exact mismatching LOOM_PROFILE_END.
         lmAssert(false, "Profiler zero stack check failed: %s",
             mCurrentLoomProfilerEntry == NULL ? "[entry NULL]" :
             mCurrentLoomProfilerEntry->mRoot == NULL ? "[entry root NULL] (try compiling as a debug build or with LOOM_PROFILE_AT_ENGINE_START enabled for more info)" :

--- a/loom/common/core/performance.cpp
+++ b/loom/common/core/performance.cpp
@@ -526,6 +526,18 @@ void LoomProfiler::hashPop(LoomProfilerRoot *expected)
     }
 }
 
+void LoomProfiler::hashZeroCheck()
+{
+    if (mStackDepth != 0)
+    {
+        lmAssert(false, "Profiler zero stack check failed: %s",
+            mCurrentLoomProfilerEntry == NULL ? "[entry NULL]" :
+            mCurrentLoomProfilerEntry->mRoot == NULL ? "[entry root NULL]" :
+            mCurrentLoomProfilerEntry->mRoot->mName
+        );
+    }
+    
+}
 
 static S32 rootDataCompare(const void *s1, const void *s2)
 {
@@ -606,6 +618,8 @@ static void LoomProfilerEntryDumpRecurse(LoomProfilerEntry *data, char *buffer, 
 
 void LoomProfiler::dump()
 {
+    LOOM_PROFILE_ZERO_CHECK()
+
     bool enableSave = mEnabled;
 
     mEnabled = false;

--- a/loom/common/core/performance.cpp
+++ b/loom/common/core/performance.cpp
@@ -26,6 +26,9 @@
 
 loom_allocator_t *gProfilerAllocator = NULL;
 
+// Uncomment for better stack imbalance error reporting
+//#define LOOM_PROFILE_AT_ENGINE_START 1
+
 #ifndef NPERFORMANCE
 
 #include <stdio.h>
@@ -114,7 +117,13 @@ void finishProfilerBlock(profilerBlock_t *block)
 LoomProfilerRoot    *LoomProfilerRoot::sRootList = NULL;
 LoomProfiler        *gLoomProfiler = NULL;
 static LoomProfiler aProfiler; // allocate the global profiler
-#define LOOM_PROFILE_AT_ENGINE_START    false
+
+#if (defined(LOOM_PROFILE_AT_ENGINE_START) && LOOM_PROFILE_AT_ENGINE_START) || defined(LOOM_DEBUG)
+#define LOOM_PROFILE_AT_ENGINE_START_INTERNAL true
+#else
+#define LOOM_PROFILE_AT_ENGINE_START_INTERNAL false
+#endif
+
 
 #if LOOM_PLATFORM_IS_APPLE
 
@@ -273,9 +282,9 @@ LoomProfiler::LoomProfiler()
 
    mProfileList = NULL;
 
-   mEnabled = LOOM_PROFILE_AT_ENGINE_START;   
+   mEnabled = LOOM_PROFILE_AT_ENGINE_START_INTERNAL;   
 
-   mNextEnable = LOOM_PROFILE_AT_ENGINE_START;
+   mNextEnable = LOOM_PROFILE_AT_ENGINE_START_INTERNAL;
 
    mStackDepth = 0;
    gLoomProfiler = this;
@@ -532,7 +541,7 @@ void LoomProfiler::hashZeroCheck()
     {
         lmAssert(false, "Profiler zero stack check failed: %s",
             mCurrentLoomProfilerEntry == NULL ? "[entry NULL]" :
-            mCurrentLoomProfilerEntry->mRoot == NULL ? "[entry root NULL]" :
+            mCurrentLoomProfilerEntry->mRoot == NULL ? "[entry root NULL] (try compiling as a debug build or with LOOM_PROFILE_AT_ENGINE_START enabled for more info)" :
             mCurrentLoomProfilerEntry->mRoot->mName
         );
     }

--- a/loom/common/core/performance.h
+++ b/loom/common/core/performance.h
@@ -32,6 +32,26 @@
 #endif // NTELEMETRY
 #endif
 
+/**
+ * Loom Performance Profiler
+ * 
+ * Loom also ships with a full featured hierarchical profiler. See the Loom docs
+ * under Guides > LoomScript > Profiling for a full discussion on how to activate and
+ * interpret the profiler. Briefly, the profiler tracks how long it takes to execute
+ * various blocks of code, how many times they are run, which blocks are run by others,
+ * and also shows the average, min, and max time spent in each block.
+ * 
+ * In terms of C++ code, three macros mark blocks. You can either explicitly mark the 
+ * beginning and end of blocks with LOOM_PROFILE_START and LOOM_PROFILE_END, or use
+ * LOOM_PROFILE_SCOPE to measure time spent in the current C++ scope starting from the
+ * point of the macro.
+ * 
+ * If LUA_GC_PROFILE_ENABLED is set to 1, then the profiler also tracks time spent in 
+ * Lua's GC.
+ *
+ * Loom integrates with RAD Telemetry. (http://www.radgametools.com/telemetry.htm)
+ */
+
 // Wrapper around our performance tracking library, which is currently
 // RAD Game Tools' Telemetry. We highly recommend this tool, however, due
 // to licensing concerns, cannot include it in the standard distro. This

--- a/loom/common/core/performance.h
+++ b/loom/common/core/performance.h
@@ -148,6 +148,8 @@ public:
 
     /// Helper function for macro definition PROFILE_END
     void hashPop(LoomProfilerRoot *expected);
+
+    void hashZeroCheck();
 };
 
 extern LoomProfiler *gLoomProfiler;
@@ -202,6 +204,8 @@ struct LoomProfilerEntry
     if (gLoomProfiler) gLoomProfiler->hashPush(&pdata ## name ## obj)
 
 #define LOOM_PROFILE_END(name)    if (gLoomProfiler) gLoomProfiler->hashPop(&pdata ## name ## obj)
+
+#define LOOM_PROFILE_ZERO_CHECK() if (gLoomProfiler) gLoomProfiler->hashZeroCheck();
 
 class LoomScopedProfiler {
 public:

--- a/loom/common/core/performance.h
+++ b/loom/common/core/performance.h
@@ -47,7 +47,7 @@
  * point of the macro.
  * 
  * If LUA_GC_PROFILE_ENABLED is set to 1, then the profiler also tracks time spent in 
- * Lua's GC.
+ * LoomScript's garbage collector.
  *
  * Loom integrates with RAD Telemetry. (http://www.radgametools.com/telemetry.htm)
  */

--- a/loom/engine/bindings/loom/lmApplicationTasks.cpp
+++ b/loom/engine/bindings/loom/lmApplicationTasks.cpp
@@ -33,8 +33,6 @@ extern "C"
 
 void loom_tick()
 {
-    LOOM_PROFILE_START(loom_tick);
-
     LSLuaState *vm = NULL;
 
     vm = LoomApplication::getReloadQueued() ? NULL : LoomApplication::getRootVM();
@@ -47,7 +45,7 @@ void loom_tick()
     performance_tick();
 
     profilerBlock_t p = { "loom_tick", platform_getMilliseconds(), 8 };
-
+    
     if (LoomApplication::getReloadQueued())
     {
         LoomApplication::reloadMainAssembly();
@@ -82,8 +80,6 @@ void loom_tick()
         Loom2D::Stage::smMainStage->invokeRenderStage();
 
     finishProfilerBlock(&p);
-
-    LOOM_PROFILE_END(loom_tick);
 }
 }
 

--- a/loom/engine/bindings/loom/lmApplicationTasks.cpp
+++ b/loom/engine/bindings/loom/lmApplicationTasks.cpp
@@ -33,6 +33,8 @@ extern "C"
 
 void loom_tick()
 {
+    LOOM_PROFILE_START(loom_tick);
+
     LSLuaState *vm = NULL;
 
     vm = LoomApplication::getReloadQueued() ? NULL : LoomApplication::getRootVM();
@@ -80,6 +82,11 @@ void loom_tick()
         Loom2D::Stage::smMainStage->invokeRenderStage();
 
     finishProfilerBlock(&p);
+
+    LOOM_PROFILE_END(loom_tick);
+
+    LOOM_PROFILE_ZERO_CHECK()
+
 }
 }
 

--- a/loom/script/runtime/lsProfiler.cpp
+++ b/loom/script/runtime/lsProfiler.cpp
@@ -338,9 +338,6 @@ void LSProfiler::dump(lua_State *L)
     lmLog(gProfilerLogGroup, "Please note: Profiling under JIT does not include native function calls.");
     lmLog(gProfilerLogGroup, "switch to the interpreted VM in order to gather native method timings");
 #endif
-
-    // does the actual dumping
-    reset(L);
 }
 
 


### PR DESCRIPTION
… and removed the faulty loom_tick block as the dump happens within it

Also tested random START/END calls and the only one that fell through was having a START with no END (stack overflow gets caught, but it's possible to not overflow before dumping/reset), which now gets caught with the zero stack check before dumping.