### PR TITLE
Memory, cleanup, other fixes

### DIFF
--- a/docs/examples/ModestMapsExample/src/ModestMapsExample.ls
+++ b/docs/examples/ModestMapsExample/src/ModestMapsExample.ls
@@ -68,10 +68,12 @@ package
             
             landmarkViewer = new LandmarkViewer(_map);
             landmarkViewer.loadVolcanoes("assets/volcanoes.tsv");
+            landmarkViewer.runVolcanoShowcase();
+            //landmarkViewer.profileVolcanoShowcase();
             
             
             //marker placement logic
-            _map.addEventListener(TouchEvent.TOUCH, touchHandler);          
+            _map.addEventListener(TouchEvent.TOUCH, touchHandler);
             _markerHoldTimer = new Timer(PinHoldTime);
             _markerHoldTimer.onComplete = function() 
             { 
@@ -104,7 +106,7 @@ package
             
             if (keycode == LoomKey.C) trace(_map.getCenter());
             
-            if (keycode == LoomKey.S) landmarkViewer.runVolcanoShowcase();
+            if (keycode == LoomKey.S) landmarkViewer.volcanoShowcase ? landmarkViewer.stopVolcanoShowcase() : landmarkViewer.runVolcanoShowcase();
             
             //process zooming
             if (keycode == LoomKey.EQUALS)

--- a/loom/common/core/assert.h
+++ b/loom/common/core/assert.h
@@ -79,9 +79,10 @@ void loom_fireAssertCallback();
 // Use lmAssert when the check is just a sanity check and stripping it out
 // will not have any side effects
 #if LOOM_COMPILER == LOOM_COMPILER_MSVC
-#define lmCheck(condition, errmsg, ...)                                                                                                          \
+#define lmCheck(condition, errmsg, ...) do {                                                                                                      \
     if (!(condition)) {                                                                                                                           \
         char *lmAssertBuf = (char *)malloc(strlen(errmsg) + strlen(# condition) + 32); /* Allocate our buffer with 32 bytes of breathing room. */ \
+        if (lmAssertBuf == NULL) { platform_error("Assertion message allocation failed! The unformatted message follows."); lmSafeCheck(condition, errmsg); break; } \
         strcpy(lmAssertBuf, "Assert failed [%s@%d] (" # condition "): ");              /* Begin with our standard "assert failed" prefix. */      \
         strcpy(lmAssertBuf + strlen(lmAssertBuf), errmsg);                             /* Append our message to the end of our format string. */  \
         strcpy(lmAssertBuf + strlen(lmAssertBuf), "\n");                               /* Append a new line to the end for good measure. */       \
@@ -89,18 +90,19 @@ void loom_fireAssertCallback();
         __debugbreak();                                                                                                                           \
         loom_fireAssertCallback();                                                                                                                \
         abort();                                                                                                                                  \
-    }
+    } } while(0);
 #else
-#define lmCheck(condition, errmsg, args ...)                                                                                                     \
+#define lmCheck(condition, errmsg, args ...) do {                                                                                                 \
     if (!(condition)) {                                                                                                                           \
         char *lmAssertBuf = (char *)malloc(strlen(errmsg) + strlen(# condition) + 32); /* Allocate our buffer with 32 bytes of breathing room. */ \
+        if (lmAssertBuf == NULL) { platform_error("Assertion message allocation failed! The unformatted message follows."); lmSafeCheck(condition, errmsg); break; } \
         strcpy(lmAssertBuf, "Assert failed [%s@%d] (" # condition "): \n");            /* Begin with our standard "assert failed" prefix. */      \
         strcpy(lmAssertBuf + strlen(lmAssertBuf), errmsg);                             /* Append our message to the end of our format string. */  \
         strcpy(lmAssertBuf + strlen(lmAssertBuf), "\n");                               /* Append a new line to the end for good measure. */       \
         platform_error(lmAssertBuf, __FILE__, __LINE__, ## args);                                                                                 \
         loom_fireAssertCallback();                                                                                                                \
         abort();                                                                                                                                  \
-    }
+    } while (0);
 #endif
 
 #endif

--- a/loom/common/core/assert.h
+++ b/loom/common/core/assert.h
@@ -90,7 +90,8 @@ void loom_fireAssertCallback();
         __debugbreak();                                                                                                                           \
         loom_fireAssertCallback();                                                                                                                \
         abort();                                                                                                                                  \
-    } } while(0);
+    } \
+} while(0);
 #else
 #define lmCheck(condition, errmsg, args ...) do {                                                                                                 \
     if (!(condition)) {                                                                                                                           \
@@ -102,7 +103,8 @@ void loom_fireAssertCallback();
         platform_error(lmAssertBuf, __FILE__, __LINE__, ## args);                                                                                 \
         loom_fireAssertCallback();                                                                                                                \
         abort();                                                                                                                                  \
-    } while (0);
+    } \
+} while (0);
 #endif
 
 #endif

--- a/loom/common/core/performance.cpp
+++ b/loom/common/core/performance.cpp
@@ -659,6 +659,7 @@ void LoomProfiler::dump()
 
     qsort((void *)&rootVector[0], rootVector.size(), sizeof(LoomProfilerRoot *), rootDataCompare);
 
+    lmLogError(gProfilerLogGroup, "");
     lmLogError(gProfilerLogGroup, "Profiler Data Dump:");
     lmLogError(gProfilerLogGroup, "Ordered by non-sub total time -");
     lmLogError(gProfilerLogGroup, "%%NSTime  %% Time  AvgTime  MaxTime  MinTime Invoke # Name");

--- a/loom/common/platform/platformTime.c
+++ b/loom/common/platform/platformTime.c
@@ -120,12 +120,16 @@ typedef struct loom_win32_precisionTimer_t
 loom_precision_timer_t loom_startTimer()
 {
     loom_win32_precisionTimer_t *t = lmAlloc(NULL, sizeof(loom_win32_precisionTimer_t));
-
-    QueryPerformanceFrequency(&t->mFrequency);
-    QueryPerformanceCounter(&t->mPerfCountCurrent);
+    loom_resetTimer(t);
     return t;
 }
 
+void loom_resetTimer(loom_precision_timer_t timer)
+{
+    loom_win32_precisionTimer_t *t = (void *)timer;
+    QueryPerformanceFrequency(&t->mFrequency);
+    QueryPerformanceCounter(&t->mPerfCountCurrent);
+}
 
 int loom_readTimer(loom_precision_timer_t timer)
 {
@@ -136,6 +140,17 @@ int loom_readTimer(loom_precision_timer_t timer)
     QueryPerformanceCounter(&endCount);
     elapsed = 1000.0 * ((double)(endCount.QuadPart - t->mPerfCountCurrent.QuadPart) / (double)t->mFrequency.QuadPart);
     return (int)elapsed;
+}
+
+double loom_readTimerNano(loom_precision_timer_t timer)
+{
+    double elapsed = 0.f;
+    loom_win32_precisionTimer_t *t = (void *)timer;
+    LARGE_INTEGER               endCount;
+
+    QueryPerformanceCounter(&endCount);
+    elapsed = 1e6 * ((double)(endCount.QuadPart - t->mPerfCountCurrent.QuadPart) / (double)t->mFrequency.QuadPart);
+    return elapsed;
 }
 
 

--- a/loom/common/platform/platformTime.h
+++ b/loom/common/platform/platformTime.h
@@ -32,7 +32,9 @@ int platform_getMilliseconds();
 
 typedef void * loom_precision_timer_t;
 loom_precision_timer_t loom_startTimer();
+void loom_resetTimer(loom_precision_timer_t timer);
 int loom_readTimer(loom_precision_timer_t timer);
+double loom_readTimerNano(loom_precision_timer_t timer);
 void loom_destroyTimer(loom_precision_timer_t timer);
 
 #ifdef __cplusplus

--- a/loom/engine/bindings/loom/lmApplicationTasks.cpp
+++ b/loom/engine/bindings/loom/lmApplicationTasks.cpp
@@ -74,10 +74,6 @@ void loom_tick()
 
     GFX::Texture::tick();
 
-    LOOM_PROFILE_START(garbageCollection);
-    if (vm) lualoom_gc_update(vm->VM());
-    LOOM_PROFILE_END(garbageCollection);
-
     if(Loom2D::Stage::smMainStage)
         Loom2D::Stage::smMainStage->invokeRenderStage();
 

--- a/loom/engine/loom2d/l2dStage.cpp
+++ b/loom/engine/loom2d/l2dStage.cpp
@@ -20,6 +20,7 @@
 
 
 #include "loom/engine/loom2d/l2dStage.h"
+#include "loom/engine/bindings/loom/lmApplication.h"
 #include "loom/graphics/gfxGraphics.h"
 #include "loom/common/config/applicationConfig.h"
 #include "loom/common/core/log.h"
@@ -129,7 +130,11 @@ void Stage::render(lua_State *L)
     GFX::Graphics::endFrame();
     LOOM_PROFILE_END(stageRenderEnd);
 
-
+    LSLuaState *vm = LoomApplication::getReloadQueued() ? NULL : LoomApplication::getRootVM();
+    LOOM_PROFILE_START(garbageCollection);
+    if (vm) lualoom_gc_update(vm->VM());
+    LOOM_PROFILE_END(garbageCollection);
+    
     LOOM_PROFILE_START(waitForVSync);
     /* Update the screen! */
     SDL_GL_SwapWindow(sdlWindow);

--- a/loom/script/CMakeLists.txt
+++ b/loom/script/CMakeLists.txt
@@ -38,14 +38,16 @@ set (SOURCE_FILES ${CPP_FILES} ${H_FILES})
 # Define target & libraries to link
 add_library (${TARGET_NAME} STATIC ${SOURCE_FILES})
 
-if (MSVC)
+if (MSVC OR (APPLE AND NOT LOOM_BUILD_IOS))
     target_link_libraries(${TARGET_NAME} "SDL2-static" "SDL2main")
+else()
+    target_link_libraries(${TARGET_NAME} "${LOOM_SDL2_LIB}" )
 endif(MSVC)
 
 if (ANDROID)
-    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon "${LOOM_SDL2_LIB}" )
+    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon )
 endif(ANDROID)
 
 if (LINUX)
-    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon "${LOOM_SDL2_LIB}" )
+    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon )
 endif(LINUX)

--- a/loom/script/CMakeLists.txt
+++ b/loom/script/CMakeLists.txt
@@ -38,10 +38,14 @@ set (SOURCE_FILES ${CPP_FILES} ${H_FILES})
 # Define target & libraries to link
 add_library (${TARGET_NAME} STATIC ${SOURCE_FILES})
 
+if (MSVC)
+    target_link_libraries(${TARGET_NAME} "SDL2-static" "SDL2main")
+endif(MSVC)
+
 if (ANDROID)
-    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon )
+    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon "${LOOM_SDL2_LIB}" )
 endif(ANDROID)
 
 if (LINUX)
-    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon )
+    target_link_libraries(${TARGET_NAME} -lz LoomVendor LoomCommon "${LOOM_SDL2_LIB}" )
 endif(LINUX)

--- a/loom/script/compiler/lsBuildInfo.cpp
+++ b/loom/script/compiler/lsBuildInfo.cpp
@@ -165,7 +165,7 @@ void ModuleBuildInfo::parse(json_t *json)
 
         if (path.size() && (path[path.size() - 1] != *platform_getFolderDelimiter()))
         {
-            if (path.size() && path.size())
+            if (path.size())
             {
                 path += platform_getFolderDelimiter();
             }

--- a/loom/script/native/core/system/lmGC.cpp
+++ b/loom/script/native/core/system/lmGC.cpp
@@ -192,7 +192,7 @@ public:
             int bytesPerRun = cycleCollectedBytes / cycleRuns;
             
             // The new run limit
-            runLimit = (int)round(runLimit + (targetRuns - runLimit) * runAmortization);
+            runLimit = (int)floor(0.5 + runLimit + (targetRuns - runLimit) * runAmortization);
             
             // Limit the persistent limit based on the min and max
             updateRunLimit = runLimit < runLimitMin ? runLimitMin : runLimit > runLimitMax ? runLimitMax : runLimit;

--- a/loom/script/native/core/system/lmString.cpp
+++ b/loom/script/native/core/system/lmString.cpp
@@ -608,7 +608,7 @@ public:
                     lua_pushstring(L, temp);
                     lua_rawset(L, -3);
                 }
-                else if (found - start == 0) {
+                else if (found != str && found - start == 0) {
                     lua_pushnumber(L, count++);
                     lua_pushstring(L, "");
                     lua_rawset(L, -3);

--- a/loom/script/runtime/lsInstanceRT.cpp
+++ b/loom/script/runtime/lsInstanceRT.cpp
@@ -545,6 +545,7 @@ static int lsr_gctracker(lua_State *L)
     {
         GCTracker *gct = (GCTracker *)lua_topointer(L, 1);
         lmAssert(gct, "unable to get GCTracker");
+        LSProfiler::registerMemoryUsage(gct->type, -gct->allocated);
         LSProfiler::registerGC(gct->type, gct->methodBase);
     }
 

--- a/loom/script/runtime/lsLuaState.h
+++ b/loom/script/runtime/lsLuaState.h
@@ -94,8 +94,10 @@ class LSLuaState {
 
 public:
 
+    static size_t allocatedBytes;
+
     LSLuaState() :
-        compiling(false), loadingAssembly(0), L(NULL) 
+        compiling(false), loadingAssembly(0), L(NULL)
     {
 
 #ifdef LOOM_DEBUG

--- a/loom/script/runtime/lsRuntime.h
+++ b/loom/script/runtime/lsRuntime.h
@@ -474,6 +474,7 @@ struct GCTracker
 {
     Type       *type;
     MethodBase *methodBase;
+    int         allocated;
 };
 }
 #endif

--- a/sdk/src/loom/ModestMaps/Map.ls
+++ b/sdk/src/loom/ModestMaps/Map.ls
@@ -72,6 +72,8 @@ package loom.modestmaps
         public var onProviderChange:MapProviderChange;
         public var onMapRender:MapChange;
         
+        private var tempExtent:MapExtent = new MapExtent(0, 0, 0, 0);
+        
         protected var baseMapWidth:Number;
         protected var baseMapHeight:Number;
         protected var mapWidth:Number;
@@ -318,13 +320,11 @@ package loom.modestmaps
         */
         public function getExtent():MapExtent
         {
-            var extent:MapExtent = new MapExtent(0, 0, 0, 0);
-            
             Debug.assert(mapProvider, "WHOAH, no mapProvider in getExtent!");
             
-            extent.northWest = mapProvider.coordinateLocation(grid.topLeftCoordinate);
-            extent.southEast = mapProvider.coordinateLocation(grid.bottomRightCoordinate);
-            return extent;
+            tempExtent.northWest = mapProvider.coordinateLocationStatic(grid.topLeftCoordinate);
+            tempExtent.southEast = mapProvider.coordinateLocationStatic(grid.bottomRightCoordinate);
+            return tempExtent;
         }
     
        /*
@@ -356,7 +356,15 @@ package loom.modestmaps
         {
             return Math.floor(grid.zoomLevel);
         }
-
+/*
+        * Return the fractional current zoom level of the map.
+        *
+        * @return   zoom number
+        */
+        public function getZoomFractional():Number
+        {
+            return grid.zoomLevel;
+        }
     
        /**
         * Set new map size, dispatch MapEvent.RESIZED. 

--- a/sdk/src/loom/ModestMaps/core/Coordinate.ls
+++ b/sdk/src/loom/ModestMaps/core/Coordinate.ls
@@ -10,11 +10,6 @@ package loom.modestmaps.core
         public var column:Number;
         public var zoom:Number;
 
-        //NOTE_TEC: added to avoid unnecessary Coordinate object generation at times
-        public var zoomToRow:Number;
-        public var zoomToCol:Number;
-        
-
         public function Coordinate(row:Number, column:Number, zoom:Number)
         {
             this.row = row;
@@ -39,6 +34,13 @@ package loom.modestmaps.core
             return new Coordinate(row, column, zoom);
         }
         
+        public function copyFrom(coord:Coordinate)
+        {
+            row = coord.row;
+            column = coord.column;
+            zoom = coord.zoom;
+        }
+        
        /**
         * Return a new coordinate that corresponds to that of the tile containing this one
         */
@@ -56,8 +58,8 @@ package loom.modestmaps.core
         public function zoomToInPlace(destination:Number):void
         {
             var zoomPow:Number = Math.pow(2, destination - zoom);
-            zoomToCol = column * zoomPow;
-            zoomToRow = row * zoomPow;
+            column *= zoomPow;
+            row *= zoomPow;
         }
         
         public function zoomBy(distance:Number):Coordinate

--- a/sdk/src/loom/ModestMaps/core/TileGrid.ls
+++ b/sdk/src/loom/ModestMaps/core/TileGrid.ls
@@ -1119,17 +1119,14 @@ package loom.modestmaps.core
             //checkNodes(quadRoot);
             
             var time = Platform.getTime();
-            var timeLimit = 2;
-            var iterationLimit = 100;
+            var timeLimit = 1;
+            var iterationLimit = 1000;
             var pruned = 0;
             var iterations = 0;
             
-            //trace("Pruning nodes... "+quadRoot.descendants);
             while (quadRoot.descendants > MAX_QUAD_NODES && Platform.getTime()-time < timeLimit && iterations < iterationLimit) {
-            //if (quadRoot.descendants > MAX_QUAD_NODES) {
                 var node = quadRoot;
                 var levels = 0;
-                //var path:Vector.<int> = [];
                 var retries:int = 0;
                 var nextChild:int = -1;
                 while (node && !node.isPrunable()) {
@@ -1143,7 +1140,6 @@ package loom.modestmaps.core
                     }
                     if (next) {
                         node = next;
-                        //path.push(nextChild);
                         retries = 0;
                         nextChild = -1;
                         levels++;
@@ -1157,15 +1153,13 @@ package loom.modestmaps.core
                     }
                     iterations++;
                 }
-                //trace("Path: "+path);
                 if (node) {
-                    //trace("Found prunable node "+node+" "+levels+" levels deep");
                     node.destroy();
                     pruned++;
                 }
             }
             // Uncomment to trace the quad node pruning status
-            //if (iterations > 0) trace("Pruned "+pruned+" / "+quadRoot.descendants+" nodes "+checkNodePrunable+" / "+checkNodeTotal+" prunable "+iterations+" iterations "+QuadNode.poolCount+" in pool");
+            //if (iterations > 0) trace("Pruned "+pruned+" / "+quadRoot.descendants+" nodes in "+(Platform.getTime()-time)+" ms "+checkNodePrunable+" / "+checkNodeTotal+" prunable "+iterations+" iterations "+QuadNode.poolCount+" in pool");
         }
         
         private function checkNodes(node:QuadNode) {

--- a/sdk/src/loom/ModestMaps/core/TileGrid.ls
+++ b/sdk/src/loom/ModestMaps/core/TileGrid.ls
@@ -62,7 +62,7 @@ package loom.modestmaps.core
         /** this is the maximum size of tileCache (visible tiles will also be kept in the cache).  
          *  the larger this is, the more texture memory will be needed to store the loaded images. */     
         //public static var MaxTilesToKeep:int = 256;// 256*256*4bytes = 0.25MB ... so 128 tiles is 32MB of memory, minimum!
-        public static var MaxTilePixels:int = 256*256*256; // the maximum amount of tiles to keep represented as the number of pixels (to be tile size agnostic)
+        public static var MaxTilePixels:int = 128*256*256; // the maximum amount of tiles to keep represented as the number of pixels (to be tile size agnostic)
         
         /** 0 or 1, really: 2 will load *lots* of extra tiles */
         public static var TileBuffer:int = 1;
@@ -74,6 +74,13 @@ package loom.modestmaps.core
 
         private static const TILE_DEPTH_SHIFT = 16;
         public static var TileTimeoutMs = 60000;
+        
+        static public const MAX_QUAD_NODES = 1000;
+        static private const sHelperCoord:Coordinate = new Coordinate(0, 0, 0);
+        static private const sHelperTL:Coordinate = new Coordinate(0, 0, 0);
+        static private const sHelperTR:Coordinate = new Coordinate(0, 0, 0);
+        static private const sHelperBL:Coordinate = new Coordinate(0, 0, 0);
+        static private const sHelperBR:Coordinate = new Coordinate(0, 0, 0);
         
         //public var debug = true;
         public var debug = false;
@@ -413,9 +420,10 @@ package loom.modestmaps.core
             invalidatePosition();
             
             // update centerRow and centerCol for sorting the tileQueue in processQueue()
-            centerCoordinate.zoomToInPlace(currentTileZoom);
-            centerColumn = centerCoordinate.zoomToCol;
-            centerRow = centerCoordinate.zoomToRow;
+            sHelperCoord.copyFrom(centerCoordinate);
+            sHelperCoord.zoomToInPlace(currentTileZoom);
+            centerColumn = sHelperCoord.column;
+            centerRow = sHelperCoord.row;
 
             onRendered();
 
@@ -453,36 +461,41 @@ package loom.modestmaps.core
             //make sure our coordinates are all up to date
             recalculateCoordinates();
 
+            sHelperTL.copyFrom(_topLeftCoordinate);
+            sHelperTR.copyFrom(_topRightCoordinate);
+            sHelperBL.copyFrom(_bottomLeftCoordinate);
+            sHelperBR.copyFrom(_bottomRightCoordinate);
+            
             // find start and end columns for the visible tiles, at current tile zoom
             // we project all four corners to take account of potential rotation in worldMatrix
-            _topLeftCoordinate.zoomToInPlace(currentTileZoom);
-            _bottomRightCoordinate.zoomToInPlace(currentTileZoom);
-            _topRightCoordinate.zoomToInPlace(currentTileZoom);
-            _bottomLeftCoordinate.zoomToInPlace(currentTileZoom);
+            sHelperTL.zoomToInPlace(currentTileZoom);
+            sHelperBR.zoomToInPlace(currentTileZoom);
+            sHelperTR.zoomToInPlace(currentTileZoom);
+            sHelperBL.zoomToInPlace(currentTileZoom);
             
             // optionally pad it out a little bit more with a tile buffer
             // TODO: investigate giving a directional bias to TILE_BUFFER when panning quickly
             // NB:- I'm pretty sure these calculations are accurate enough that using 
             //      Math.ceil for the maxCols will load one column too many -- Tom         
-            MinColRow.x = Math.floor(minCoord(_topLeftCoordinate.zoomToCol, 
-                                                _bottomRightCoordinate.zoomToCol,
-                                                _topRightCoordinate.zoomToCol,
-                                                _bottomLeftCoordinate.zoomToCol)) - TileBuffer;
-            MaxColRow.x = Math.floor(maxCoord(_topLeftCoordinate.zoomToCol,
-                                                _bottomRightCoordinate.zoomToCol,
-                                                _topRightCoordinate.zoomToCol,
-                                                _bottomLeftCoordinate.zoomToCol)) + TileBuffer;
-            MinColRow.y = Math.floor(minCoord(_topLeftCoordinate.zoomToRow,
-                                                _bottomRightCoordinate.zoomToRow,
-                                                _topRightCoordinate.zoomToRow,
-                                                _bottomLeftCoordinate.zoomToRow)) - TileBuffer;
-            MaxColRow.y = Math.floor(maxCoord(_topLeftCoordinate.zoomToRow,
-                                                _bottomRightCoordinate.zoomToRow,
-                                                _topRightCoordinate.zoomToRow,
-                                                _bottomLeftCoordinate.zoomToRow)) + TileBuffer;
+            MinColRow.x = Math.floor(minCoord(sHelperTL.column, 
+                                                sHelperBR.column,
+                                                sHelperTR.column,
+                                                sHelperBL.column)) - TileBuffer;
+            MaxColRow.x = Math.floor(maxCoord(sHelperTL.column,
+                                                sHelperBR.column,
+                                                sHelperTR.column,
+                                                sHelperBL.column)) + TileBuffer;
+            MinColRow.y = Math.floor(minCoord(sHelperTL.row,
+                                                sHelperBR.row,
+                                                sHelperTR.row,
+                                                sHelperBL.row)) - TileBuffer;
+            MaxColRow.y = Math.floor(maxCoord(sHelperTL.row,
+                                                sHelperBR.row,
+                                                sHelperTR.row,
+                                                sHelperBL.row)) + TileBuffer;
             
-            TopLeftColRow.x = _topLeftCoordinate.zoomToCol;
-            TopLeftColRow.y = _topLeftCoordinate.zoomToRow;
+            TopLeftColRow.x = sHelperTL.column;
+            TopLeftColRow.y = sHelperTL.row;
             
             clampColRow(MinColRow);
             clampColRow(MaxColRow);
@@ -842,22 +855,21 @@ package loom.modestmaps.core
             // Recompute tile grid bounds for all zoom levels
             var zoom = currentTileZoom;
             var zoomMax = maxZoom;
-            var coord = tempCoord;
+            var coord = sHelperCoord;
             var gb:GridBounds;
             for (var z:int = 0; z <= zoomMax; z++) {
                 
-                tempCoord.setVals(minRow, minCol, zoom);
-                tempCoord.zoomToInPlace(z);
-                var zMinCol = tempCoord.zoomToCol;
-                var zMinRow = tempCoord.zoomToRow;
-                tempCoord.setVals(maxRow, maxCol, zoom);
-                tempCoord.zoomToInPlace(z);
-                
                 gb = _tileGridBounds[z];
-                gb.minCol = Math.floor(zMinCol);
-                gb.minRow = Math.floor(zMinRow);
-                gb.maxCol = Math.floor(tempCoord.zoomToCol);
-                gb.maxRow = Math.floor(tempCoord.zoomToRow);
+                
+                coord.setVals(minRow, minCol, zoom);
+                coord.zoomToInPlace(z);
+                gb.minCol = Math.floor(coord.column);
+                gb.minRow = Math.floor(coord.row);
+                
+                coord.setVals(maxRow, maxCol, zoom);
+                coord.zoomToInPlace(z);
+                gb.maxCol = Math.floor(coord.column);
+                gb.maxRow = Math.floor(coord.row);
             }
             
             // Set remaining visible tiles not in current zoom
@@ -1056,6 +1068,7 @@ package loom.modestmaps.core
             }
             currentCovered = tile;
             
+            pruneNodes();
             
             // Prune tiles not in the well from the cache
             time = Platform.getTime();
@@ -1096,6 +1109,78 @@ package loom.modestmaps.core
             
             updateHud();
             
+        }
+        
+        private var checkNodeTotal:int;
+        private var checkNodePrunable:int;
+        
+        private function pruneNodes() {
+            // Uncomment to count the amount of prunable and total nodes
+            //checkNodes(quadRoot);
+            
+            var time = Platform.getTime();
+            var timeLimit = 2;
+            var iterationLimit = 100;
+            var pruned = 0;
+            var iterations = 0;
+            
+            //trace("Pruning nodes... "+quadRoot.descendants);
+            while (quadRoot.descendants > MAX_QUAD_NODES && Platform.getTime()-time < timeLimit && iterations < iterationLimit) {
+            //if (quadRoot.descendants > MAX_QUAD_NODES) {
+                var node = quadRoot;
+                var levels = 0;
+                //var path:Vector.<int> = [];
+                var retries:int = 0;
+                var nextChild:int = -1;
+                while (node && !node.isPrunable()) {
+                    if (nextChild == -1) nextChild = Math.randomRangeInt(0, 3);
+                    var next:QuadNode;
+                    switch (nextChild) {
+                        case 0: next = node.a; break;
+                        case 1: next = node.b; break;
+                        case 2: next = node.c; break;
+                        case 3: next = node.d; break;
+                    }
+                    if (next) {
+                        node = next;
+                        //path.push(nextChild);
+                        retries = 0;
+                        nextChild = -1;
+                        levels++;
+                    } else {
+                        retries++;
+                        if (retries >= 4) {
+                            node = null;
+                            break;
+                        }
+                        nextChild = (nextChild+1)%4;
+                    }
+                    iterations++;
+                }
+                //trace("Path: "+path);
+                if (node) {
+                    //trace("Found prunable node "+node+" "+levels+" levels deep");
+                    node.destroy();
+                    pruned++;
+                }
+            }
+            // Uncomment to trace the quad node pruning status
+            //if (iterations > 0) trace("Pruned "+pruned+" / "+quadRoot.descendants+" nodes "+checkNodePrunable+" / "+checkNodeTotal+" prunable "+iterations+" iterations "+QuadNode.poolCount+" in pool");
+        }
+        
+        private function checkNodes(node:QuadNode) {
+            if (node == quadRoot) {
+                checkNodeTotal = 0;
+                checkNodePrunable = 0;
+            } else {
+                if (!node) return;
+                checkNodeTotal++;
+                if (node.isPrunable()) checkNodePrunable++;
+            }
+            checkNodes(node.a);
+            checkNodes(node.b);
+            checkNodes(node.c);
+            checkNodes(node.d);
         }
 
 
@@ -1466,9 +1551,6 @@ package loom.modestmaps.core
             tile.updateRepop();
             tile.isVisible = true;
         }
-        
-        // for use in requestParentLoad
-        private var tempCoord:Coordinate = new Coordinate(0,0,0);
         
         /** create a tile and add it to the queue - WARNING: this is buggy for the current zoom level, it's only used for parent zooms when MaxParentLoad is > 0 */ 
         private function requestParentLoad():Tile
@@ -1932,7 +2014,7 @@ package loom.modestmaps.core
             
             tilePainter.reset();
             
-            quadRoot = new QuadNode(null, -1, 0, 0, 0);
+            quadRoot = new QuadNode();
             
             dirty = true;
             
@@ -1958,8 +2040,8 @@ package loom.modestmaps.core
             _tileGridBounds = new Vector.<GridBounds>(_maxZoom + 1);
             for (i = 0; i < _tileGridBounds.length; i++) _tileGridBounds[i] = new GridBounds();
             
-            tl = tl.zoomTo(0);
-            br = br.zoomTo(0);
+            tl.zoomToInPlace(0);
+            br.zoomToInPlace(0);
             
             minTx = tl.column * tileWidth;
             maxTx = br.column * tileWidth;
@@ -1998,10 +2080,12 @@ package loom.modestmaps.core
             // so that they can be compared against minTx etc.
             
             var topLeftPoint:Point = inverse.transformCoord(0,0);
-            var topLeft:Coordinate = new Coordinate(topLeftPoint.y, topLeftPoint.x, matrixZoomLevel).zoomTo(0);
+            var topLeft:Coordinate = new Coordinate(topLeftPoint.y, topLeftPoint.x, matrixZoomLevel);
+            topLeft.zoomToInPlace(0);
 
             var bottomRightPoint:Point = inverse.transformCoord(mapWidth, mapHeight);
-            var bottomRight:Coordinate = new Coordinate(bottomRightPoint.y, bottomRightPoint.x, matrixZoomLevel).zoomTo(0);
+            var bottomRight:Coordinate = new Coordinate(bottomRightPoint.y, bottomRightPoint.x, matrixZoomLevel);
+            bottomRight.zoomToInPlace(0);
             
             // apply horizontal constraints
             

--- a/sdk/src/loom/ModestMaps/core/painter/TilePool.ls
+++ b/sdk/src/loom/ModestMaps/core/painter/TilePool.ls
@@ -14,8 +14,8 @@ package loom.modestmaps.core.painter
      */ 
     public class TilePool 
     {
-        protected static const MIN_POOL_SIZE:int = 128;
-        protected static const MAX_NEW_TILES:int = 512;
+        protected static const MIN_POOL_SIZE:int = 1;
+        protected static const MAX_NEW_TILES:int = 25;
         
         protected var pool:Vector.<Tile> = [];
         protected var tileCreatorFunc:Function;

--- a/sdk/src/loom/ModestMaps/geo/AbstractProjection.ls
+++ b/sdk/src/loom/ModestMaps/geo/AbstractProjection.ls
@@ -13,6 +13,8 @@ package loom.modestmaps.geo
     public class AbstractProjection implements IProjection
     {
         protected const HELPER_POINT:Point;
+        protected const HELPER_COORD:Coordinate = new Coordinate(0, 0, 0);
+        protected const HELPER_LOCATION:Location = new Location(0, 0);
         
         // linear transformation, if any.
         protected var T:Transformation;
@@ -93,11 +95,24 @@ package loom.modestmaps.geo
         */
         public function coordinateLocation(coordinate:Coordinate):Location
         {
-            coordinate = coordinate.zoomTo(zoom);
-            HELPER_POINT.x = coordinate.column;
-            HELPER_POINT.y = coordinate.row;
+            HELPER_COORD.setVals(coordinate.row, coordinate.column, coordinate.zoom);
+            HELPER_COORD.zoomToInPlace(zoom);
+            HELPER_POINT.x = HELPER_COORD.column;
+            HELPER_POINT.y = HELPER_COORD.row;
             unproject(HELPER_POINT);
             return new Location(180*HELPER_POINT.y/Math.PI, 180*HELPER_POINT.x/Math.PI);
+        }
+        
+        public function coordinateLocationStatic(coordinate:Coordinate):Location
+        {
+            HELPER_COORD.setVals(coordinate.row, coordinate.column, coordinate.zoom);
+            HELPER_COORD.zoomToInPlace(zoom);
+            HELPER_POINT.x = HELPER_COORD.column;
+            HELPER_POINT.y = HELPER_COORD.row;
+            unproject(HELPER_POINT);
+            HELPER_LOCATION.lat = 180*HELPER_POINT.y/Math.PI;
+            HELPER_LOCATION.lon = 180*HELPER_POINT.x/Math.PI;
+            return HELPER_LOCATION;
         }
     }
 }

--- a/sdk/src/loom/ModestMaps/geo/IProjection.ls
+++ b/sdk/src/loom/ModestMaps/geo/IProjection.ls
@@ -29,6 +29,7 @@ package loom.modestmaps.geo
         * Return untransformed and unprojected location for a coordinate.
         */
         function coordinateLocation(coordinate:Coordinate):Location;
+        function coordinateLocationStatic(coordinate:Coordinate):Location;
         
         function toString():String;
     }

--- a/sdk/src/loom/ModestMaps/mapproviders/AbstractMapProvider.ls
+++ b/sdk/src/loom/ModestMaps/mapproviders/AbstractMapProvider.ls
@@ -104,6 +104,10 @@ package loom.modestmaps.mapproviders
         {
             return __projection.coordinateLocation(coordinate);
         }
+        public function coordinateLocationStatic(coordinate:Coordinate):Location
+        {
+            return __projection.coordinateLocationStatic(coordinate);
+        }
 
         public function get tileWidth():Number
         {

--- a/sdk/src/loom/ModestMaps/mapproviders/IMapProvider.ls
+++ b/sdk/src/loom/ModestMaps/mapproviders/IMapProvider.ls
@@ -25,6 +25,7 @@ package loom.modestmaps.mapproviders
         * @return untransformed and unprojected location for a coordinate.
         */
         function coordinateLocation(coordinate:Coordinate):Location;
+        function coordinateLocationStatic(coordinate:Coordinate):Location;
     
        /**
         * Get top left outer-zoom limit and bottom right inner-zoom limits,

--- a/sdk/src/loom/ModestMaps/mapproviders/WMSMapProvider.ls
+++ b/sdk/src/loom/ModestMaps/mapproviders/WMSMapProvider.ls
@@ -85,8 +85,8 @@ package loom.modestmaps.mapproviders
 			var magicZoom:Number = Math.log(2*quadrantWidth) / Math.LN2;        	
 
 			// apply that number os a zoom, it's basically getting us tile coordinates for zoom level 25.something...
-        	bottomLeftCoord = bottomLeftCoord.zoomTo(magicZoom);
-        	topRightCoord = topRightCoord.zoomTo(magicZoom);
+        	bottomLeftCoord.zoomToInPlace(magicZoom);
+        	topRightCoord.zoomToInPlace(magicZoom);
         	
         	// flip and offset so we have correct minx,miny,maxx,maxy
         	var minx:Number = bottomLeftCoord.column - quadrantWidth;

--- a/sdk/src/loom/ModestMaps/mapproviders/microsoft/MicrosoftProvider.ls
+++ b/sdk/src/loom/ModestMaps/mapproviders/microsoft/MicrosoftProvider.ls
@@ -53,7 +53,7 @@ package loom.modestmaps.mapproviders.microsoft
             }
     
             // Microsoft don't have a zoom level 0 right now:
-            __topLeftOutLimit.zoomTo(1);
+            __topLeftOutLimit.zoomToInPlace(1);
         }
    
         public function toString():String

--- a/sdk/src/system/GC.ls
+++ b/sdk/src/system/GC.ls
@@ -52,9 +52,9 @@ class GC {
     public static native function collect(cmd:Number = STEP, data:Number = 0);
 
     /**
-     *  Gets the ammount of RAM allocated by the VM in megabytes
+     *  Gets the amount of RAM allocated by the VM in mebibytes (MiB)
      */
-    public static native function getAllocatedMemory():int;
+    public static native function getAllocatedMemory():Number;
 
     /**
      * Sets a warning level in megabytes for the VM
@@ -64,30 +64,6 @@ class GC {
      * @param   megabytes The memory threshold in megabytes that causes a warning when surpassed
      */
     public static native function setMemoryWarningLevel(megabytes:int);
-
-    /**
-     * Sets a backoff time to avoid running the incremental GC once a single step has
-     * exceeded the backoff threshold.
-     *
-     * @param milliseconds The amount of time to back off from running incremental GC
-     * once a single step has exceeded the backoff threshold, default is 250ms
-     */
-    public static native function setBackOffTime(milliseconds:int = 250);
-
-    /**
-     * Sets the amount of time necessary to trigger a GC backoff in milliseconds.
-     *
-     * @param milliseconds The amount of time that when exceeded, triggers a GC backoff interval.
-     * The default is 1, so a GC step taking 2 milliseconds would trigger the backoff.
-     */
-    public static native function setBackOffThreshold(milliseconds:int = 1);
-
-    /**
-     * Sets the GC increment size for a single step of a GC collection.
-     *
-     * @param size The size of a single GC increment, larger numbers are more aggressive
-     */
-    public static native function setIncrementSize(size:int = 16);
 
     /**
      *  Runs a frame of GC collection (incremental), there is internal logic

--- a/sdk/src/test/tests/TestString.ls
+++ b/sdk/src/test/tests/TestString.ls
@@ -47,8 +47,7 @@ class TestString extends LegacyTest
     
     function test()
     {
-        
-        assert("|X|A|X|B|X|C|X|".split("|X|").length == 5);        
+        assert("|X|A|X|B|X|C|X||X|DoubleCommaOnLeft|X|".split("|X|").length == 7);        
         
         var svalue = "This is a Test!";
         

--- a/sdk/src/unittest/LegacyTest.ls
+++ b/sdk/src/unittest/LegacyTest.ls
@@ -38,8 +38,9 @@ public class LegacyTest
     {
         currentTestFailureCount ++;
 
-        if (msg)
-            currentTestErrors.pushSingle(msg);
+        var callstack = Debug.getCallStack();
+        var cinfo = callstack[2];
+        currentTestErrors.pushSingle(cinfo.source+":"+cinfo.line+" "+(msg ? msg : ""));
     }
 
     protected static function handleAssertSuccess():void
@@ -80,7 +81,12 @@ public class LegacyTest
 
     protected function fail()
     {
-        Assert.fail("Legacy test failed: "+name);
+        var msg = "";
+        msg += "Legacy test failed: "+name+" ("+currentTestFailureCount+" failures)";
+        for (var i:int = 0; i < currentTestErrors.length; i++) {
+            msg += "\n\t"+currentTestErrors[i];
+        }
+        Assert.fail(msg);
     }
 
     public function begin()


### PR DESCRIPTION
Landmark Viewer™ now has automatic profiling capabilities
Less allocation in maps and landmark viewer in general
Moved GC steps to before vsync
Added allocation size tracking to profiler
Added different view on profiled memory (sorted methods by total allocation)
Coordinate zoomToInPlace now has different behavior (it now zooms the actual col/row values in place and doesn't store in a separate target)
QuadNodes now use a pool and get cleaned up (this could probably be tweaked more)

TODONE:
Finish lmGC cleanup and clean up QuadNode pruning