### PR TITLE
Simple GL state managment implementation

### DIFF
--- a/loom/graphics/CMakeLists.txt
+++ b/loom/graphics/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Debugging support
 # add_definitions(-DBGFX_CONFIG_DEBUG=1)
 
-set ( GRAPHICS_SRC gfxGraphics.cpp gfxQuadRenderer.cpp gfxTexture.cpp gfxScript.cpp gfxVectorRenderer.cpp gfxVectorGraphics.cpp)
+set ( GRAPHICS_SRC gfxGraphics.cpp gfxQuadRenderer.cpp gfxTexture.cpp gfxScript.cpp gfxVectorRenderer.cpp gfxVectorGraphics.cpp gfxStateManager.c)
 set (LOOM_VENDOR ${CMAKE_CURRENT_SOURCE_DIR}/../vendor)
 set (NANOVG ${LOOM_VENDOR}/nanovg/src)
 set (NANOSVG ${LOOM_VENDOR}/nanosvg/src)

--- a/loom/graphics/gfxStateManager.c
+++ b/loom/graphics/gfxStateManager.c
@@ -1,0 +1,44 @@
+/*
+ * ===========================================================================
+ * Loom SDK
+ * Copyright 2011, 2012, 2013
+ * The Game Engine Company, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================
+ */
+
+#include "gfxStateManager.h"
+
+bool gGLStates[GFX_OPENGL_STATE_MAX] = {true, true};
+
+bool Graphics_IsGLStateValid(enum Graphics_GLState state)
+{
+    return gGLStates[(int)state];
+}
+
+void Graphics_InvalidateGLState(enum Graphics_GLState state)
+{
+    gGLStates[(int)state] = false;
+}
+
+void Graphics_SetCurrentGLState(enum Graphics_GLState state)
+{
+    int i;
+    for (i = 0; i < (int)GFX_OPENGL_STATE_MAX; i++)
+    {
+        gGLStates[i] = false;
+    }
+    
+    gGLStates[(int)state] = true;
+}

--- a/loom/graphics/gfxStateManager.h
+++ b/loom/graphics/gfxStateManager.h
@@ -20,7 +20,11 @@
 
 #pragma once
 
-
+/*
+ * This set of functions enables interoperability of multiple renderers that
+ * break each others GL states. It lets a renderer know if it's GL state needs
+ * to set up it's state again or not.
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,8 +38,23 @@ enum Graphics_GLState {
     GFX_OPENGL_STATE_MAX    = 2,
 };
 
+/*
+ * Checks if given state is still valid.
+ * Returns false if it was invalidated or another state was set.
+ */
 bool Graphics_IsGLStateValid(enum Graphics_GLState state);
+
+/*
+ * Invalidates given state. Another state might still be valid if
+ * the invalidated state was already invalid. This should be called
+ * when somehting changes that affects given state.
+ */
 void Graphics_InvalidateGLState(enum Graphics_GLState state);
+
+/*
+ * Invalidates all other states and sets the given state as valid.
+ * This should called after a GL state has been set up for given state.
+ */
 void Graphics_SetCurrentGLState(enum Graphics_GLState state);
 
 #ifdef __cplusplus

--- a/loom/graphics/gfxStateManager.h
+++ b/loom/graphics/gfxStateManager.h
@@ -1,0 +1,43 @@
+/*
+ * ===========================================================================
+ * Loom SDK
+ * Copyright 2011, 2012, 2013
+ * The Game Engine Company, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ===========================================================================
+ */
+
+#pragma once
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#else
+#include <stdbool.h>
+#endif
+
+enum Graphics_GLState {
+    GFX_OPENGL_STATE_NANOVG = 0,
+    GFX_OPENGL_STATE_QUAD   = 1,
+    GFX_OPENGL_STATE_MAX    = 2,
+};
+
+bool Graphics_IsGLStateValid(enum Graphics_GLState state);
+void Graphics_InvalidateGLState(enum Graphics_GLState state);
+void Graphics_SetCurrentGLState(enum Graphics_GLState state);
+
+#ifdef __cplusplus
+};
+#endif

--- a/loom/vendor/nanovg/src/nanovg_lm_gl.h
+++ b/loom/vendor/nanovg/src/nanovg_lm_gl.h
@@ -1084,28 +1084,26 @@ static void glnvg__renderFlush(void* uptr)
 
     if (gl->ncalls > 0) {
 
-        
-            // Setup require GL state.
-            
-			if (!Graphics_IsGLStateValid(GFX_OPENGL_STATE_NANOVG))
-			{
-				LGL->glUseProgram(gl->shader.prog);
-                LGL->glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-                LGL->glEnable(GL_CULL_FACE);
-                LGL->glCullFace(GL_BACK);
-                LGL->glFrontFace(GL_CCW);
-                LGL->glEnable(GL_BLEND);
-                LGL->glDisable(GL_DEPTH_TEST);
-                LGL->glDisable(GL_SCISSOR_TEST);
-                LGL->glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-                LGL->glStencilMask(0xffffffff);
-                LGL->glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
-                LGL->glStencilFunc(GL_ALWAYS, 0, 0xffffffff);
-                LGL->glActiveTexture(GL_TEXTURE0);
-                LGL->glBindTexture(GL_TEXTURE_2D, 0);
-                
-                Graphics_SetCurrentGLState(GFX_OPENGL_STATE_NANOVG);
-            }
+        // Setup require GL state.
+        if (!Graphics_IsGLStateValid(GFX_OPENGL_STATE_NANOVG))
+        {
+            LGL->glUseProgram(gl->shader.prog);
+            LGL->glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+            LGL->glEnable(GL_CULL_FACE);
+            LGL->glCullFace(GL_BACK);
+            LGL->glFrontFace(GL_CCW);
+            LGL->glEnable(GL_BLEND);
+            LGL->glDisable(GL_DEPTH_TEST);
+            LGL->glDisable(GL_SCISSOR_TEST);
+            LGL->glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+            LGL->glStencilMask(0xffffffff);
+            LGL->glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+            LGL->glStencilFunc(GL_ALWAYS, 0, 0xffffffff);
+            LGL->glActiveTexture(GL_TEXTURE0);
+            LGL->glBindTexture(GL_TEXTURE_2D, 0);
+
+            Graphics_SetCurrentGLState(GFX_OPENGL_STATE_NANOVG);
+        }
 #if NANOVG_GL_USE_STATE_FILTER
         gl->boundTexture = 0;
         gl->stencilMask = 0xffffffff;

--- a/loom/vendor/nanovg/src/nanovg_lm_gl.h
+++ b/loom/vendor/nanovg/src/nanovg_lm_gl.h
@@ -108,6 +108,7 @@ extern "C" {
 #include <string.h>
 #include <math.h>
 #include "nanovg.h"
+#include "loom/graphics/gfxStateManager.h"
 
 enum GLNVGuniformLoc {
     GLNVG_LOC_VIEWSIZE,
@@ -1083,22 +1084,28 @@ static void glnvg__renderFlush(void* uptr)
 
     if (gl->ncalls > 0) {
 
-        // Setup require GL state.
-        LGL->glUseProgram(gl->shader.prog);
-
-        LGL->glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-        LGL->glEnable(GL_CULL_FACE);
-        LGL->glCullFace(GL_BACK);
-        LGL->glFrontFace(GL_CCW);
-        LGL->glEnable(GL_BLEND);
-        LGL->glDisable(GL_DEPTH_TEST);
-        LGL->glDisable(GL_SCISSOR_TEST);
-        LGL->glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
-        LGL->glStencilMask(0xffffffff);
-        LGL->glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
-        LGL->glStencilFunc(GL_ALWAYS, 0, 0xffffffff);
-        LGL->glActiveTexture(GL_TEXTURE0);
-        LGL->glBindTexture(GL_TEXTURE_2D, 0);
+        
+            // Setup require GL state.
+            
+			if (!Graphics_IsGLStateValid(GFX_OPENGL_STATE_NANOVG))
+			{
+				LGL->glUseProgram(gl->shader.prog);
+                LGL->glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
+                LGL->glEnable(GL_CULL_FACE);
+                LGL->glCullFace(GL_BACK);
+                LGL->glFrontFace(GL_CCW);
+                LGL->glEnable(GL_BLEND);
+                LGL->glDisable(GL_DEPTH_TEST);
+                LGL->glDisable(GL_SCISSOR_TEST);
+                LGL->glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+                LGL->glStencilMask(0xffffffff);
+                LGL->glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+                LGL->glStencilFunc(GL_ALWAYS, 0, 0xffffffff);
+                LGL->glActiveTexture(GL_TEXTURE0);
+                LGL->glBindTexture(GL_TEXTURE_2D, 0);
+                
+                Graphics_SetCurrentGLState(GFX_OPENGL_STATE_NANOVG);
+            }
 #if NANOVG_GL_USE_STATE_FILTER
         gl->boundTexture = 0;
         gl->stencilMask = 0xffffffff;
@@ -1149,9 +1156,6 @@ static void glnvg__renderFlush(void* uptr)
 #if defined NANOVG_GL3
         LGL->glBindVertexArray(0);
 #endif	
-        LGL->glDisable(GL_CULL_FACE);
-        LGL->glBindBuffer(GL_ARRAY_BUFFER, 0);
-        LGL->glUseProgram(0);
         glnvg__bindTexture(gl, 0);
     }
 


### PR DESCRIPTION
This removes some  "cleanup" that the two renderers were doing, so
they can reuse the state they set up before.

Additionally, some whitespace errors are fixed.

This is a crude implementation, but it works. Maybe it could be improved further when other issues are resolved (QuadRenderer batching bug for ex.).