### PR TITLE
HTTP cleanup warning

### DIFF
--- a/loom/engine/bindings/loom/lmHTTPRequest.cpp
+++ b/loom/engine/bindings/loom/lmHTTPRequest.cpp
@@ -144,6 +144,7 @@ public:
             utByteArray *result = lmNew(NULL) utByteArray();
             result->writeString("Request cancelled by user.");
             respond(this, LOOM_HTTP_ERROR, result);
+            requestPending = false;
         }
     }
 

--- a/loom/engine/bindings/loom/lmHTTPRequest.cpp
+++ b/loom/engine/bindings/loom/lmHTTPRequest.cpp
@@ -30,8 +30,12 @@ using namespace LS;
 lmDefineLogGroup(gHTTPRequestLogGroup, "HTTPRequest", 1, LoomLogInfo);
 
 class HTTPRequest {
-public:
+private:
 
+    bool requestPending;
+
+public:
+    
     utString method;
     utString body;
     utString url;
@@ -54,6 +58,8 @@ public:
         followRedirects          = true;
         id = -1;
 
+        requestPending = false;
+
         // set the Content-Type in the header
         const char *ctKey = contentType;
         if((ctKey == NULL) || (ctKey[0] == '\0'))
@@ -66,6 +72,12 @@ public:
 
     ~HTTPRequest()
     {
+        // Warn if this object is garbage collected while a requet is pending
+        if (requestPending)
+        {
+            lmLog(gHTTPRequestLogGroup, "WARNING: HTTPRequest object with url \"%s\" garbage collected before completing a pending request. Ensure references to HTTPRequest objects are maintained while requests are pending.", url.c_str())
+        }
+
         header.clear();
         cancel();
     }
@@ -116,6 +128,9 @@ public:
                                   (const char *)body.c_str(), body.length(), header,
                                   (const char *)responseCacheFile.c_str(), followRedirects);
             }
+
+            // The request has been sent!
+            requestPending = true;
         }
         return (id == -1) ? false : true;
     }
@@ -132,13 +147,19 @@ public:
         }
     }
 
+    bool isPending()
+    {
+        return requestPending;
+    }
+
     //only called internally to notfiy that the HTTPRequest has completed now
     void complete()
     {
         if (id == -1) return;
         platform_HTTPComplete(id);
-        id = -1;        
-    }    
+        id = -1;
+        requestPending = false;
+    }
 
     static bool isConnected()
     {
@@ -184,6 +205,7 @@ static int registerLoomHTTPRequest(lua_State *L)
        .addMethod("getHeaderField", &HTTPRequest::getHeaderField)
        .addMethod("send", &HTTPRequest::send)
        .addMethod("cancel", &HTTPRequest::cancel)
+       .addMethod("isPending", &HTTPRequest::isPending)
        .addStaticMethod("isConnected", &HTTPRequest::isConnected)
        .addVar("method", &HTTPRequest::method)
        .addVar("body", &HTTPRequest::body)

--- a/sdk/src/loom/HTTPRequest.ls
+++ b/sdk/src/loom/HTTPRequest.ls
@@ -64,6 +64,11 @@ package loom
          *  Cancels an in progress HTTPRequest.
          */
         public native function cancel();
+        
+        /**
+         *  If a HTTPRequest is currently pending
+         */
+        public native function isPending():Boolean;
 
         /**
          *  Called when the HTTPRequest is successful. Passes the response from the HTTP server as a ByteArray.


### PR DESCRIPTION
Improvements:
- Added a flag to HTTPRequest that indicates if a request is pending
- If the HTTPRequest object is cleaned up while a request is pending, a
  user friendly warning is produced