### PR TITLE
Constructor Optimizations

### DIFF
--- a/docs/examples/ScriptBenchmark/src/BenchmarkAllocation.ls
+++ b/docs/examples/ScriptBenchmark/src/BenchmarkAllocation.ls
@@ -32,13 +32,15 @@ package
     }
 
     /*
-     * Benchmark for raw field access
+     * Benchmark for to test allocation of a representative script class with
+     * some inheritance.
      */
     public class BenchmarkAllocation
     {
         public function run()
         {
             trace("Running - BenchmarkAllocation");
+
             var start = Platform.getTime();
 
             var i = 0;

--- a/docs/examples/ScriptBenchmark/src/BenchmarkAllocation.ls
+++ b/docs/examples/ScriptBenchmark/src/BenchmarkAllocation.ls
@@ -2,7 +2,15 @@ package
 {
     import system.platform.Platform;
 
-    class SomeFields
+    class SimpleObject
+    {
+    }
+
+    class SimpleObject2 extends SimpleObject
+    {
+    }
+
+    class SimpleObject3 extends SimpleObject2
     {
         public var x = 1.0;
         public var y = 2.0;
@@ -13,20 +21,17 @@ package
     /*
      * Benchmark for raw field access
      */
-    public class BenchmarkFieldAccess
+    public class BenchmarkAllocation
     {
         public function run()
         {
-            trace("Running - BenchmarkFieldAccess");
+            trace("Running - BenchmarkAllocation");
             var start = Platform.getTime();
 
             var i = 0;
-
-            var sf = new SomeFields();
-
-            while (i < 10000000)
+            while (i < 100000)
             {
-                sf.w = sf.w + sf.x + sf.y + sf.z;
+                var sf = new SimpleObject3();
                 i++;
             }
 

--- a/docs/examples/ScriptBenchmark/src/BenchmarkAllocation.ls
+++ b/docs/examples/ScriptBenchmark/src/BenchmarkAllocation.ls
@@ -4,14 +4,27 @@ package
 
     class SimpleObject
     {
+        function SimpleObject()
+        {
+            
+        }
     }
 
     class SimpleObject2 extends SimpleObject
     {
+        function SimpleObject2()
+        {
+            
+        }
     }
 
     class SimpleObject3 extends SimpleObject2
     {
+        function SimpleObject3()
+        {
+
+        }
+
         public var x = 1.0;
         public var y = 2.0;
         public var z = 3.0;
@@ -35,7 +48,7 @@ package
                 i++;
             }
 
-            trace("Completed in ", Platform.getTime() - start, "ms");
+            trace("BenchmarkAllocation completed in ", Platform.getTime() - start, "ms");
 
         }
     }

--- a/docs/examples/ScriptBenchmark/src/BenchmarkFieldAccess.ls
+++ b/docs/examples/ScriptBenchmark/src/BenchmarkFieldAccess.ls
@@ -24,7 +24,7 @@ package
 
             var sf = new SomeFields();
 
-            while (i < 10000000)
+            while (i < 100000)
             {
                 sf.w = sf.w + sf.x + sf.y + sf.z;
                 i++;

--- a/docs/examples/ScriptBenchmark/src/BenchmarkFunctionCall.ls
+++ b/docs/examples/ScriptBenchmark/src/BenchmarkFunctionCall.ls
@@ -36,7 +36,7 @@ package
 
             var start = Platform.getTime();
 
-            while (i < 10000000)
+            while (i < 100000)
             {
                 sc.doIt(i);
                 i++;
@@ -48,7 +48,7 @@ package
 
             i = 0;
 
-            while (i < 10000000)
+            while (i < 100000)
             {
                 var b = SomeCalls.staticDoIt(i);
                 i++;

--- a/docs/examples/ScriptBenchmark/src/ScriptBenchmark.ls
+++ b/docs/examples/ScriptBenchmark/src/ScriptBenchmark.ls
@@ -25,7 +25,11 @@ package
                     break;
                 case 1:
                     new BenchmarkFunctionCall().run();
-                    break;    
+                    break; 
+
+                case 2:
+                    new BenchmarkAllocation().run();
+                    break;
 
                 default:
                     toRun = 0;

--- a/loom/engine/loom2d/l2dQuad.cpp
+++ b/loom/engine/loom2d/l2dQuad.cpp
@@ -129,10 +129,7 @@ void Quad::render(lua_State *L)
 
     if (renderState.isClipping()) GFX::Graphics::setClipRect((int)renderState.clipRect.x, (int)renderState.clipRect.y, (int)renderState.clipRect.width, (int)renderState.clipRect.height);
 
-    GFX::VertexPosColorTex *v   = GFX::QuadRenderer::getQuadVertices(nativeTextureID, 
-                                                                        4, 
-                                                                        tinted || renderState.alpha != 1.f,
-                                                                        blendSrc, blendDst);
+    GFX::VertexPosColorTex *v = GFX::QuadRenderer::getQuadVertexMemory(4, nativeTextureID, blendSrc, blendDst);
     GFX::VertexPosColorTex *src = quadVertices;
 
     if (!v)

--- a/loom/engine/loom2d/l2dQuadBatch.cpp
+++ b/loom/engine/loom2d/l2dQuadBatch.cpp
@@ -71,11 +71,11 @@ void QuadBatch::render(lua_State *L)
     bool isIdentity = mtx.isIdentity();
     if((renderState.alpha == 1.0f) && isIdentity)
     {
-        GFX::QuadRenderer::batch(nativeTextureID, quadData, 4 * numQuads, blendSrc, blendDst);
+        GFX::QuadRenderer::batch(quadData, 4 * numQuads, nativeTextureID, blendSrc, blendDst);
         return;
     }
 
-    GFX::VertexPosColorTex *v   = GFX::QuadRenderer::getQuadVertices(nativeTextureID, 4 * numQuads, true, blendSrc, blendDst);
+    GFX::VertexPosColorTex *v = GFX::QuadRenderer::getQuadVertexMemory(nativeTextureID, 4 * numQuads, blendSrc, blendDst);
     if (!v)
     {
         return;

--- a/loom/graphics/CMakeLists.txt
+++ b/loom/graphics/CMakeLists.txt
@@ -15,7 +15,6 @@ if(APPLE)
 
     add_definitions( -U__STRICT_ANSI__ -Wfatal-errors -Wunused-value )
 
-
     if(LOOM_BUILD_IOS EQUAL 1)
         #set ( GRAPHICS_SRC ${GRAPHICS_SRC} gfxGraphicsIOS.mm )
         #if (LOOM_IOS_LEGACY EQUAL 1)
@@ -37,7 +36,6 @@ if(APPLE)
 endif()
 
 if(ANDROID)
-        add_definitions ( -std=c++0x )
         add_definitions( -DLOOM_RENDERER_OPENGLES2=1 )
         include_directories( ${LOOM_INCLUDE_FOLDERS} )
 endif()    
@@ -47,7 +45,6 @@ if (MSVC)
 endif()
 
 if (LINUX)
-    add_definitions ( -std=c++0x )
     set ( BGFX_SRC ${BGFX_SRC} ${LOOMBGFX_SOURCE_DIR}/renderer_gl.cpp ${LOOMBGFX_SOURCE_DIR}/glcontext_external.cpp )
     set ( GRAPHICS_SRC ${GRAPHICS_SRC} gfxGraphicsAndroid.cpp )
 
@@ -59,6 +56,8 @@ if (FLASH)
     include_directories( ${LOOMBGFX_INCLUDE_DIR}/compat/osx )
 
 endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x" )
 
 add_library( LoomGraphics ${NANOVG_SRC} ${GRAPHICS_SRC} )
 target_link_libraries(LoomGraphics LoomVendor )

--- a/loom/graphics/gfxQuadRenderer.cpp
+++ b/loom/graphics/gfxQuadRenderer.cpp
@@ -40,52 +40,36 @@ namespace GFX
 {
 lmDefineLogGroup(gGFXQuadRendererLogGroup, "GFXQuadRenderer", 1, LoomLogInfo);
 
-static unsigned int sProgramPosColorTex;
-static unsigned int sProgramPosTex;
+static GLuint sProgramPosColorTex;
+static GLuint sProgramPosTex;
 
-static unsigned int sProgram_posAttribLoc;
-static unsigned int sProgram_posColorLoc;
-static unsigned int sProgram_posTexCoordLoc;
-static unsigned int sProgram_texUniform;
-static unsigned int sProgram_mvp;
+static GLuint sProgram_posAttribLoc;
+static GLuint sProgram_posColorLoc;
+static GLuint sProgram_posTexCoordLoc;
+static GLuint sProgram_texUniform;
+static GLuint sProgram_mvp;
 
-static unsigned int sIndexBufferHandle;
+static GLuint sSrcBlend = GL_SRC_ALPHA;
+static GLuint sDstBlend = GL_ONE_MINUS_SRC_ALPHA;
 
-static bool sTinted = true;
-
-unsigned int sSrcBlend = GL_SRC_ALPHA;
-unsigned int sDstBlend = GL_ONE_MINUS_SRC_ALPHA;
-
-unsigned int QuadRenderer::vertexBuffers[MAXVERTEXBUFFERS];
-
-VertexPosColorTex* QuadRenderer::vertexData[MAXVERTEXBUFFERS];
-
-void* QuadRenderer::vertexDataMemory = NULL;
-
-int QuadRenderer::maxVertexIdx[MAXVERTEXBUFFERS];
-
-int QuadRenderer::numVertexBuffers;
-
-int               QuadRenderer::currentVertexBufferIdx;
-VertexPosColorTex *QuadRenderer::currentVertexPtr;
-int               QuadRenderer::vertexCount;
-
-int QuadRenderer::currentIndexBufferIdx;
-
+GLuint QuadRenderer::indexBufferId;
+GLuint QuadRenderer::vertexBufferId;
+VertexPosColorTex* QuadRenderer::batchedVertices;
+size_t QuadRenderer::batchedVertexCount;
 TextureID QuadRenderer::currentTexture;
-
-// Number of quads pending submission
-int       QuadRenderer::quadCount;
 
 int QuadRenderer::numFrameSubmit;
 
 static loom_allocator_t *gQuadMemoryAllocator = NULL;
+static bool sShaderStateValid = false;
+static bool sTextureStateValid = false;
+static bool sBlendStateValid = false;
 
 void QuadRenderer::submit()
 {
     LOOM_PROFILE_SCOPE(quadSubmit);
 
-    if (quadCount <= 0)
+    if (batchedVertexCount <= 0)
     {
         return;
     }
@@ -106,29 +90,18 @@ void QuadRenderer::submit()
 
             if (!Graphics_IsGLStateValid(GFX_OPENGL_STATE_QUAD))
             {
-                // Select the shader.
-                if(sTinted)
-                    Graphics::context()->glUseProgram(sProgramPosColorTex);
-                else
-                    Graphics::context()->glUseProgram(sProgramPosTex);
+                sShaderStateValid = false;
+                sTextureStateValid = false;
+                sBlendStateValid = false;
             }
-
-            // Upload vertex data.
-            Graphics::context()->glBindBuffer(GL_ARRAY_BUFFER, vertexBuffers[currentVertexBufferIdx]);
-
-            // This commented block seems better for performance, but it's actually a lot slower on iOS.
-            // Instead we just update the entire buffer, which seems to run fine.
-            // A better solution would be having a triple buffered glMapBuffer approach.
-            /*
-            Graphics::context()->glBufferSubData(GL_ARRAY_BUFFER,
-                                                 (vertexCount - quadCount * 4) * sizeof(VertexPosColorTex),
-                                                 quadCount * 4 * sizeof(VertexPosColorTex),
-                                                 &vertexData[currentVertexBufferIdx][vertexCount - quadCount*4] );
-            */
-            Graphics::context()->glBufferData(GL_ARRAY_BUFFER, vertexCount*sizeof(VertexPosColorTex), &vertexData[currentVertexBufferIdx][0], GL_STATIC_DRAW);
-
-            if (!Graphics_IsGLStateValid(GFX_OPENGL_STATE_QUAD))
+            
+            Graphics::context()->glBindBuffer(GL_ARRAY_BUFFER, vertexBufferId);
+            
+            if (!sShaderStateValid)
             {
+                // Select the shader.
+                Graphics::context()->glUseProgram(sProgramPosColorTex);
+
                 Graphics::context()->glEnableVertexAttribArray(sProgram_posAttribLoc);
                 Graphics::context()->glEnableVertexAttribArray(sProgram_posColorLoc);
                 Graphics::context()->glEnableVertexAttribArray(sProgram_posTexCoordLoc);
@@ -144,22 +117,24 @@ void QuadRenderer::submit()
                 Graphics::context()->glVertexAttribPointer(sProgram_posTexCoordLoc,
                                                            2, GL_FLOAT, false,
                                                            sizeof(VertexPosColorTex), (void*)offsetof(VertexPosColorTex, u));
-                                                           
-                Graphics::context()->glActiveTexture(GL_TEXTURE0);
+
                 Graphics::context()->glUniform1i(sProgram_texUniform, 0);
+                Graphics::context()->glUniformMatrix4fv(sProgram_mvp, 1, GL_FALSE, Graphics::getMVP());
+
+                sShaderStateValid = true;
             }
-
-            // Set up texture state.
-            Graphics::context()->glUniformMatrix4fv(sProgram_mvp, 1, GL_FALSE, Graphics::getMVP());
-            Graphics::context()->glBindTexture(GL_TEXTURE_2D, tinfo.handle);
-
-            if (tinfo.clampOnly) {
-                tinfo.wrapU = TEXTUREINFO_WRAP_CLAMP;
-                tinfo.wrapV = TEXTUREINFO_WRAP_CLAMP;
-            }
-
-            if (!Graphics_IsGLStateValid(GFX_OPENGL_STATE_QUAD))
+            
+            if (!sTextureStateValid)
             {
+                // Set up texture state.
+                Graphics::context()->glActiveTexture(GL_TEXTURE0);
+                Graphics::context()->glBindTexture(GL_TEXTURE_2D, tinfo.handle);
+
+                if (tinfo.clampOnly) {
+                    tinfo.wrapU = TEXTUREINFO_WRAP_CLAMP;
+                    tinfo.wrapV = TEXTUREINFO_WRAP_CLAMP;
+                }
+
                 switch (tinfo.wrapU)
                 {
                     case TEXTUREINFO_WRAP_CLAMP:
@@ -203,39 +178,42 @@ void QuadRenderer::submit()
                     default:
                         lmAssert(false, "Unsupported smoothing: %d", tinfo.smoothing);
                 }
+                
+                sTextureStateValid = true;
+            }
 
+            if (!sBlendStateValid)
+            {
                 // Blend mode.
                 Graphics::context()->glEnable(GL_BLEND);
                 Graphics::context()->glBlendFuncSeparate(sSrcBlend, sDstBlend, sSrcBlend, sDstBlend);
 
-                Graphics_SetCurrentGLState(GFX_OPENGL_STATE_QUAD);
+                sBlendStateValid = true;
             }
+            
+            Graphics_SetCurrentGLState(GFX_OPENGL_STATE_QUAD);
+            
+            // Setting the buffer to null supposedly enables better performance because it enables the driver to do some optimizations.
+            Graphics::context()->glBufferData(GL_ARRAY_BUFFER, batchedVertexCount*sizeof(VertexPosColorTex), NULL, GL_STREAM_DRAW);
+            Graphics::context()->glBufferData(GL_ARRAY_BUFFER, batchedVertexCount*sizeof(VertexPosColorTex), batchedVertices, GL_STREAM_DRAW);
 
             // And bind indices and draw.
-            Graphics::context()->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, sIndexBufferHandle);
+            Graphics::context()->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBufferId);
             Graphics::context()->glDrawElements(GL_TRIANGLES,
-                                                quadCount * 6, GL_UNSIGNED_SHORT,
-                                                (void*)(currentIndexBufferIdx*sizeof(unsigned short)));
-
-
-			Graphics::context()->glDisableVertexAttribArray(sProgram_posAttribLoc);
-			Graphics::context()->glDisableVertexAttribArray(sProgram_posColorLoc);
-			Graphics::context()->glDisableVertexAttribArray(sProgram_posTexCoordLoc);
+                                                (GLsizei)(batchedVertexCount / 4 * 6), GL_UNSIGNED_SHORT,
+                                                nullptr);
         }
-
-        // Update buffer state.
-        currentIndexBufferIdx += quadCount * 6;
     }
-
-    quadCount = 0;
+    
+    batchedVertexCount = 0;
 }
 
 
-VertexPosColorTex *QuadRenderer::getQuadVertices(TextureID texture, uint16_t numVertices, bool tinted, uint32_t srcBlend, uint32_t dstBlend)
+VertexPosColorTex *QuadRenderer::getQuadVertexMemory(uint16_t vertexCount, TextureID texture, uint32_t srcBlend, uint32_t dstBlend)
 {
     LOOM_PROFILE_SCOPE(quadGetVertices);
 
-    if (!numVertices || (texture < 0) || (numVertices > MAXBATCHQUADS * 4))
+    if (!vertexCount || (texture < 0) || (vertexCount > MAXBATCHQUADS * 4))
     {
         return NULL;
     }
@@ -245,70 +223,51 @@ VertexPosColorTex *QuadRenderer::getQuadVertices(TextureID texture, uint16_t num
     lmAssert(!(numVertices % 4), "numVertices % 4 != 0");
     lmAssert(texture == Texture::getTextureInfo(texture)->id, "Texture ID signature mismatch, you might be trying to draw a disposed texture");
     loom_mutex_unlock(Texture::sTexInfoLock);
+    lmAssert(vertices);
 #endif
 
-    if (((currentTexture != TEXTUREINVALID) && (currentTexture != texture))
-        || (sTinted != tinted) || (srcBlend != sSrcBlend) || ( dstBlend != sDstBlend))
-    {
+    bool doSubmit = false;
+
+    if (currentTexture != TEXTUREINVALID && currentTexture != texture)
+        doSubmit = true;
+
+    if (srcBlend != sSrcBlend ||
+        dstBlend != sDstBlend)
+        doSubmit = true;
+
+    if ((batchedVertexCount + vertexCount) > MAXBATCHQUADS * 4)
+        doSubmit = true;
+
+    if (doSubmit)
         submit();
-        Graphics_InvalidateGLState(GFX_OPENGL_STATE_QUAD);
-    }
 
-    if ((vertexCount + numVertices) > MAXBATCHQUADS * 4)
-    {
-        submit();
+    if (currentTexture != TEXTUREINVALID && currentTexture != texture)
+        sTextureStateValid = false;
 
-        if (numVertexBuffers == MAXVERTEXBUFFERS)
-        {
-            return NULL;
-        }
+    if (srcBlend != sSrcBlend ||
+        dstBlend != sDstBlend)
+        sBlendStateValid = false;
 
-        currentVertexBufferIdx++;
-
-        if (currentVertexBufferIdx == numVertexBuffers)
-        {
-            // we need to allocate a new one
-            _initializeNextVertexBuffer();
-        }
-
-        currentIndexBufferIdx = 0;
-
-        maxVertexIdx[currentVertexBufferIdx] = 0;
-        currentVertexPtr = vertexData[currentVertexBufferIdx];
-        vertexCount      = 0;
-        quadCount        = 0;
-    }
-
-    VertexPosColorTex *returnPtr = currentVertexPtr;
-    if (!returnPtr) return NULL;
-
-    sTinted = tinted;
     sSrcBlend = srcBlend;
     sDstBlend = dstBlend;
-
-    currentVertexPtr += numVertices;
-    vertexCount      += numVertices;
-
-    maxVertexIdx[currentVertexBufferIdx] = vertexCount;
-
     currentTexture = texture;
 
-    quadCount += numVertices / 4;
-
-    return returnPtr;
+    VertexPosColorTex *currentVertices = &batchedVertices[batchedVertexCount];
+    batchedVertexCount += vertexCount;
+    return currentVertices;
 }
 
 
-void QuadRenderer::batch(TextureID texture, VertexPosColorTex *vertices, uint16_t numVertices, uint32_t srcBlend, uint32_t dstBlend)
+void QuadRenderer::batch(VertexPosColorTex *vertices, uint16_t vertexCount, TextureID texture, uint32_t srcBlend, uint32_t dstBlend)
 {
     LOOM_PROFILE_SCOPE(quadBatch);
 
-    VertexPosColorTex *verticePtr = getQuadVertices(texture, numVertices, true, srcBlend, dstBlend);
+    VertexPosColorTex *vertexPtr = getQuadVertexMemory(vertexCount, texture, srcBlend, dstBlend);
 
-    if (!verticePtr)
+    if (!vertexPtr)
         return;
 
-    memcpy((void *)verticePtr, (void *)vertices, sizeof(VertexPosColorTex) * numVertices);
+    memcpy((void *)vertexPtr, (void *)vertices, sizeof(VertexPosColorTex) * vertexCount);
 }
 
 
@@ -316,24 +275,14 @@ void QuadRenderer::beginFrame()
 {
     LOOM_PROFILE_SCOPE(quadBegin);
 
-    currentIndexBufferIdx  = 0;
-    currentVertexBufferIdx = 0;
-    vertexCount            = 0;
+    batchedVertexCount     = 0;
     currentTexture         = TEXTUREINVALID;
-    quadCount              = 0;
 
-    currentVertexPtr = vertexData[currentVertexBufferIdx];
-    maxVertexIdx[currentIndexBufferIdx] = 0;
+    sTextureStateValid = false;
+    sBlendStateValid = false;
+    sShaderStateValid = false;
 
     numFrameSubmit = 0;
-
-    // Fudge something to render with.
-/*    VertexPosColorTex v[4];
-    v[0].x =  0.5; v[0].y =  0.5; v[0].z = 0.5;
-    v[1].x =  0.5; v[1].y = -0.5; v[1].z = 0.5;
-    v[2].x = -0.5; v[2].y = -0.5; v[2].z = 0.5;
-    v[3].x = -0.5; v[3].y =  0.5; v[3].z = 0.5;
-    batch(1, &v[0], 4, 0); */
 }
 
 
@@ -347,15 +296,6 @@ void QuadRenderer::endFrame()
 void QuadRenderer::destroyGraphicsResources()
 {
     // Probably do something someday.
-}
-
-void QuadRenderer::_initializeNextVertexBuffer()
-{
-    Graphics::context()->glGenBuffers(1, &vertexBuffers[numVertexBuffers]);
-    Graphics::context()->glBindBuffer(GL_ARRAY_BUFFER, vertexBuffers[numVertexBuffers]);
-    Graphics::context()->glBufferData(GL_ARRAY_BUFFER, MAXBATCHQUADS * 4 * sizeof(VertexPosColorTex), 0, GL_STATIC_DRAW);
-    Graphics::context()->glBindBuffer(GL_ARRAY_BUFFER, 0);
-    numVertexBuffers++;
 }
 
 void QuadRenderer::initializeGraphicsResources()
@@ -383,7 +323,7 @@ void QuadRenderer::initializeGraphicsResources()
     "uniform mat4 u_mvp;\n"
     "void main()\n"
     "{\n"
-	"    gl_Position = u_mvp * a_position;\n"
+    "    gl_Position = u_mvp * a_position;\n"
     "    v_color0 = a_color0;\n"
     "    v_texcoord0 = a_texcoord0;\n"
     "}\n";
@@ -409,44 +349,16 @@ void QuadRenderer::initializeGraphicsResources()
 
     Graphics::context()->glShaderSource(vertShader, 1, &vertShaderPtr, &vertShaderLen);
     Graphics::context()->glCompileShader(vertShader);
-	GFX_SHADER_CHECK(vertShader);
+    GFX_SHADER_CHECK(vertShader);
 
     Graphics::context()->glShaderSource(fragShaderColor, 1, &fragShaderColorPtr, &fragShaderColorLen);
     Graphics::context()->glCompileShader(fragShaderColor);
-	GFX_SHADER_CHECK(fragShaderColor);
+    GFX_SHADER_CHECK(fragShaderColor);
 
     Graphics::context()->glAttachShader(quadProgColor, fragShaderColor);
     Graphics::context()->glAttachShader(quadProgColor, vertShader);
     Graphics::context()->glLinkProgram(quadProgColor);
-	GFX_PROGRAM_CHECK(quadProgColor);
-
-    /*
-    char fragShaderSrc[] =
-#if LOOM_RENDERER_OPENGLES2      
-        "precision mediump float;\n"
-#endif
-        "uniform sampler2D u_texture;\n"
-        "varying vec2 v_texcoord0;\n"
-        "void main()\n"
-        "{\n"
-        "    gl_FragColor = texture2D(u_texture, v_texcoord0);\n"
-        "}\n";
-    const int fragShaderLen = sizeof(fragShaderSrc);
-    GLchar *fragShaderPtr = &fragShaderSrc[0];
-
-    Graphics::context()->glShaderSource(fragShader, 1, &fragShaderPtr, &fragShaderLen);
-    Graphics::context()->glCompileShader(fragShader);
-    Graphics::context()->glGetShaderInfoLog(fragShader, 4096, &outLen, error);
-
-    lmLogInfo(gGFXQuadRendererLogGroup, "Program info log %s", error);
-
-    Graphics::context()->glAttachShader(quadProg, fragShader);
-    Graphics::context()->glAttachShader(quadProg, vertShader);
-    Graphics::context()->glLinkProgram(quadProg);
-    Graphics::context()->glGetProgramInfoLog(quadProg, 4096, &outLen, error);
-
-    lmLogInfo(gGFXQuadRendererLogGroup, "Program info log %s", error);
-    */
+    GFX_PROGRAM_CHECK(quadProgColor);
 
     // Get attributes and uniforms.
     sProgram_posAttribLoc = Graphics::context()->glGetAttribLocation(quadProgColor, "a_position");
@@ -459,12 +371,14 @@ void QuadRenderer::initializeGraphicsResources()
     sProgramPosColorTex = sProgramPosTex = quadProgColor;
 
     // create the single initial vertex buffer
-    numVertexBuffers = 0;
-    _initializeNextVertexBuffer();
+    Graphics::context()->glGenBuffers(1, &vertexBufferId);
+    Graphics::context()->glBindBuffer(GL_ARRAY_BUFFER, vertexBufferId);
+    Graphics::context()->glBufferData(GL_ARRAY_BUFFER, MAXBATCHQUADS * 4 * sizeof(VertexPosColorTex), 0, GL_STREAM_DRAW);
+    Graphics::context()->glBindBuffer(GL_ARRAY_BUFFER, 0);
 
     // create the single, reused index buffer
-    Graphics::context()->glGenBuffers(1, &sIndexBufferHandle);
-    Graphics::context()->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, sIndexBufferHandle);
+    Graphics::context()->glGenBuffers(1, &indexBufferId);
+    Graphics::context()->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBufferId);
     uint16_t *pIndex = (uint16_t*)lmAlloc(gQuadMemoryAllocator, sizeof(unsigned short) * 6 * MAXBATCHQUADS);
     uint16_t *pStart = pIndex;
 
@@ -479,15 +393,13 @@ void QuadRenderer::initializeGraphicsResources()
         pIndex[5] = j + 3;
     }
 
-    Graphics::context()->glBufferData(GL_ELEMENT_ARRAY_BUFFER, MAXBATCHQUADS * 6 * sizeof(uint16_t), pStart, GL_STATIC_DRAW);
+    Graphics::context()->glBufferData(GL_ELEMENT_ARRAY_BUFFER, MAXBATCHQUADS * 6 * sizeof(uint16_t), pStart, GL_STREAM_DRAW);
     Graphics::context()->glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
     lmFree(gQuadMemoryAllocator, pStart);
 
     // Create the system memory buffer for quads.
-    vertexDataMemory = lmAlloc(gQuadMemoryAllocator, MAXVERTEXBUFFERS * MAXBATCHQUADS * 4 * sizeof(VertexPosColorTex));
-    for(int i=0; i<MAXVERTEXBUFFERS; i++)
-        vertexData[i] = ((VertexPosColorTex*)vertexDataMemory) + (MAXBATCHQUADS * 4) * i;
+    batchedVertices = static_cast<VertexPosColorTex*>(lmAlloc(gQuadMemoryAllocator, MAXBATCHQUADS * 4 * sizeof(VertexPosColorTex)));
 }
 
 

--- a/loom/graphics/gfxQuadRenderer.h
+++ b/loom/graphics/gfxQuadRenderer.h
@@ -27,12 +27,9 @@ namespace GFX
 {
 
 // Define the maximum number of Quads on a single frame
-// this defaults to 65k and can be raised by increasing
-// MAXVERTEXBUFFERS (quad batches themselves use 16 bit indices)
-
+// this defaults to 128k
 // TODO: LOOM-1833 allocate this dynamically 
 #define MAXBATCHQUADS       8192
-#define MAXVERTEXBUFFERS    8  
 
 struct VertexPosColorTex
 {
@@ -47,23 +44,13 @@ class QuadRenderer
 
 private:
 
-    static unsigned int vertexBuffers[MAXVERTEXBUFFERS];
+	static GLuint vertexBufferId;
+	static GLuint indexBufferId;
 
-    static VertexPosColorTex *vertexData[MAXVERTEXBUFFERS];
-    static void* vertexDataMemory;
-
-    static int maxVertexIdx[MAXVERTEXBUFFERS];
-
-    static int numVertexBuffers;
-
-    static int               currentVertexBufferIdx;
-    static VertexPosColorTex *currentVertexPtr;
-    static int               vertexCount;
-
-    static int currentIndexBufferIdx;
+    static VertexPosColorTex *batchedVertices;
+    static size_t batchedVertexCount;
 
     static TextureID currentTexture;
-    static int       quadCount;
 
     static int numFrameSubmit;
 
@@ -76,9 +63,6 @@ private:
     // reset the quad renderer, on loss of context etc
     static void reset();
 
-    static void _initializeNextVertexBuffer();
-
-
 public:
 
     static void submit();
@@ -87,8 +71,8 @@ public:
 
     static void endFrame();
 
-    static VertexPosColorTex *getQuadVertices(TextureID texture, uint16_t numVertices, bool tinted, uint32_t srcBlend, uint32_t dstBlend);
+    static VertexPosColorTex *getQuadVertexMemory(uint16_t numVertices, TextureID texture, uint32_t srcBlend, uint32_t dstBlend);
 
-    static void batch(TextureID texture, VertexPosColorTex *vertices, uint16_t numVertices, uint32_t srcBlend, uint32_t dstBlend);
+    static void batch(VertexPosColorTex *vertices, uint16_t vertexCount, TextureID texture, uint32_t srcBlend, uint32_t dstBlend);
 };
 }

--- a/loom/script/compiler/lsJitTypeCompiler.cpp
+++ b/loom/script/compiler/lsJitTypeCompiler.cpp
@@ -411,11 +411,8 @@ void JitTypeCompiler::generateConstructor(FunctionLiteral *function,
             ExpDesc vname;
 
             BC::initExpDesc(&vname, VKNUM, 0);
-#if LOOM_ENABLE_JIT
+
             setnumV(&vname.u.nval, v->memberInfo->getOrdinal());
-#else
-            vname.u.nval = v->memberInfo->getOrdinal();
-#endif
 
             ExpDesc ethis;
             BC::singleVar(cs, &ethis, "this");

--- a/loom/script/compiler/lsJitTypeCompiler.cpp
+++ b/loom/script/compiler/lsJitTypeCompiler.cpp
@@ -431,12 +431,21 @@ void JitTypeCompiler::generateConstructor(FunctionLiteral *function,
 
     declareLocalVariables(function);
 
+    // We don't want to call super if it's a native type, as this is handled
+    // at runtime.
+    bool isSuperNative = false;
+    if(constructor->getDeclaringType() != NULL
+       && constructor->getDeclaringType()->getBaseType()
+       && constructor->getDeclaringType()->getBaseType()->isNative())
+        isSuperNative = true;
+
     // If there is no super call in this method, add it at the start so we
     // always fully initialize the class - otherwise we have to traverse
     // it at runtime which is a performance overhead.
     if(function->isConstructor
        && function->hasSuperCall == false
        && function->isNative == false
+       && !isSuperNative
        && constructor->getDeclaringType()->isPrimitive() == false)
     {
         // We want to insert a call to super(); if none is present. We need

--- a/loom/script/compiler/lsJitTypeCompiler.cpp
+++ b/loom/script/compiler/lsJitTypeCompiler.cpp
@@ -437,9 +437,9 @@ void JitTypeCompiler::generateConstructor(FunctionLiteral *function,
 
     if(constructor->getDeclaringType() == NULL
        || constructor->getDeclaringType()->getBaseType() == NULL
-       || constructor->getDeclaringType()->getBaseType()->isNativeManaged()
-       || constructor->getDeclaringType()->getBaseType()->isNative()
        || constructor->getDeclaringType()->getBaseType()->isInterface()
+       || (constructor->getDeclaringType()->getBaseType()->getConstructor()->isNative()
+           && constructor->getDeclaringType()->getBaseType()->getFullName() != "system.BaseDelegate")
        || constructor->getDeclaringType()->getBaseType()->getFullName() == "system.Object")
         skipSuper = true;
 

--- a/loom/script/compiler/lsJitTypeCompiler.cpp
+++ b/loom/script/compiler/lsJitTypeCompiler.cpp
@@ -34,6 +34,15 @@ extern "C" {
 #include "lj_bcdump.h"
 }
 
+// Enable this to get verbose logging about automatic super call generation.
+//#define DEBUG_CONSTRUCTORS
+
+#ifdef DEBUG_CONSTRUCTORS
+#   define CTOR_LOG(...) printf(__VA_ARGS__);
+#else
+#   define CTOR_LOG(...)
+#endif
+
 namespace LS {
 
 static BitOpr getassignmentbitopr(const Token *t)
@@ -443,7 +452,7 @@ void JitTypeCompiler::generateConstructor(FunctionLiteral *function,
        || constructor->getDeclaringType()->getBaseType()->getFullName() == "system.Object")
         skipSuper = true;
 
-    //printf("Considering super for %s\n", constructor->getDeclaringType()->getFullName().c_str());
+    CTOR_LOG("Considering super for %s\n", constructor->getDeclaringType()->getFullName().c_str());
 
     // If there is no super call in this method, add it at the start so we
     // always fully initialize the class - otherwise we have to traverse
@@ -454,9 +463,9 @@ void JitTypeCompiler::generateConstructor(FunctionLiteral *function,
        && skipSuper == false
        && constructor->getDeclaringType()->isPrimitive() == false)
     {
-        //printf("Generating super call to %s in constructor of %s\n",
-        //       constructor->getDeclaringType()->getBaseType() ? constructor->getDeclaringType()->getBaseType()->getFullName().c_str() : "(none)",
-        //       constructor->getDeclaringType()->getFullName().c_str());
+        CTOR_LOG("Generating super call to %s in constructor of %s\n",
+               constructor->getDeclaringType()->getBaseType() ? constructor->getDeclaringType()->getBaseType()->getFullName().c_str() : "(none)",
+               constructor->getDeclaringType()->getFullName().c_str());
 
         // We want to insert a call to super(); if none is present. We need
         // to pass "this" so it has an instance to operate on.

--- a/loom/script/compiler/lsJitTypeCompiler.cpp
+++ b/loom/script/compiler/lsJitTypeCompiler.cpp
@@ -20,6 +20,7 @@
 
 #ifdef LOOM_ENABLE_JIT
 
+#include "loom/common/core/assert.h"
 #include "loom/script/compiler/lsCompiler.h"
 #include "loom/script/compiler/lsCompilerLog.h"
 #include "loom/script/compiler/lsJitTypeCompiler.h"
@@ -34,6 +35,185 @@ extern "C" {
 }
 
 namespace LS {
+
+static BitOpr getassignmentbitopr(const Token *t)
+{
+    Tokens *tok = Tokens::getSingletonPtr();
+
+    if (t == &tok->OPERATOR_BITWISEANDASSIGNMENT)
+    {
+        return OPR_LOOM_BITAND;
+    }
+
+    if (t == &tok->OPERATOR_BITWISEORASSIGNMENT)
+    {
+        return OPR_LOOM_BITOR;
+    }
+
+    if (t == &tok->OPERATOR_BITWISEXORASSIGNMENT)
+    {
+        return OPR_LOOM_BITXOR;
+    }
+
+    if (t == &tok->OPERATOR_SHIFTLEFTASSIGNMENT)
+    {
+        return OPR_LOOM_BITLSHIFT;
+    }
+
+    if (t == &tok->OPERATOR_SHIFTRIGHTASSIGNMENT)
+    {
+        return OPR_LOOM_BITRSHIFT;
+    }
+
+    return OPR_NOBITOPR;
+}
+    
+static BinOpr getbinopr(const Token *t)
+{
+    Tokens *tok = Tokens::getSingletonPtr();
+
+    if (t == &tok->OPERATOR_PLUS)
+    {
+        return OPR_ADD;
+    }
+
+    if (t == &tok->OPERATOR_MINUS)
+    {
+        return OPR_SUB;
+    }
+
+    if (t == &tok->OPERATOR_MULTIPLY)
+    {
+        return OPR_MUL;
+    }
+
+    if (t == &tok->OPERATOR_DIVIDE)
+    {
+        return OPR_DIV;
+    }
+
+    if (t == &tok->OPERATOR_MODULO)
+    {
+        return OPR_MOD;
+    }
+
+    if (t == &tok->OPERATOR_NOTEQUAL)
+    {
+        return OPR_NE;
+    }
+
+    if (t == &tok->OPERATOR_EQUALEQUAL)
+    {
+        return OPR_EQ;
+    }
+
+    if (t == &tok->OPERATOR_LESSTHAN)
+    {
+        return OPR_LT;
+    }
+
+    if (t == &tok->OPERATOR_LESSTHANOREQUAL)
+    {
+        return OPR_LE;
+    }
+
+    if (t == &tok->OPERATOR_GREATERTHAN)
+    {
+        return OPR_GT;
+    }
+
+    if (t == &tok->OPERATOR_GREATERTHANOREQUAL)
+    {
+        return OPR_GE;
+    }
+
+    if (t == &tok->OPERATOR_LOGICALAND)
+    {
+        return OPR_AND;
+    }
+
+    if (t == &tok->OPERATOR_LOGICALOR)
+    {
+        return OPR_OR;
+    }
+
+    if (t == &tok->OPERATOR_CONCAT)
+    {
+        return OPR_CONCAT;
+    }
+
+    /*case '^': return OPR_POW;
+     * case TK_CONCAT: return OPR_CONCAT;*/
+    return OPR_NOBINOPR;
+}
+
+static BitOpr getbitopr(const Token *t)
+{
+    Tokens *tok = Tokens::getSingletonPtr();
+
+    if (t == &tok->OPERATOR_SHIFTLEFT)
+    {
+        return OPR_LOOM_BITLSHIFT;
+    }
+
+    if (t == &tok->OPERATOR_SHIFTRIGHT)
+    {
+        return OPR_LOOM_BITRSHIFT;
+    }
+
+    if (t == &tok->OPERATOR_BITWISEAND)
+    {
+        return OPR_LOOM_BITAND;
+    }
+
+    if (t == &tok->OPERATOR_BITWISEOR)
+    {
+        return OPR_LOOM_BITOR;
+    }
+
+    if (t == &tok->OPERATOR_BITWISEXOR)
+    {
+        return OPR_LOOM_BITXOR;
+    }
+
+    return OPR_NOBITOPR;
+}
+
+static BinOpr getassignmentopr(const Token *t)
+{
+    Tokens *tok = Tokens::getSingletonPtr();
+
+    if (t == &tok->OPERATOR_MULTIPLYASSIGNMENT)
+    {
+        return OPR_MUL;
+    }
+
+    if (t == &tok->OPERATOR_DIVIDEASSIGNMENT)
+    {
+        return OPR_DIV;
+    }
+
+    if (t == &tok->OPERATOR_PLUSASSIGNMENT)
+    {
+        return OPR_ADD;
+    }
+
+    if (t == &tok->OPERATOR_MINUSASSIGNMENT)
+    {
+        return OPR_SUB;
+    }
+
+    if (t == &tok->OPERATOR_MODULOASSIGNMENT)
+    {
+        return OPR_MOD;
+    }
+
+    // Sometimes we depend on failing to identify so warning here is inappropriate.
+    // LSWarning("Could not identify assignment operator '%s'.", t->value.str().c_str());
+
+    return OPR_NOBINOPR;
+}
+
 void JitTypeCompiler::compile(ClassDeclaration *classDeclaration)
 {
     JitTypeCompiler compiler;
@@ -42,7 +222,6 @@ void JitTypeCompiler::compile(ClassDeclaration *classDeclaration)
     compiler.cls        = classDeclaration;
     compiler._compile();
 }
-
 
 void JitTypeCompiler::initCodeState(CodeState *codeState, FuncState *funcState,
                                     const utString& source)
@@ -88,24 +267,6 @@ void JitTypeCompiler::closeCodeState(CodeState *codeState)
 
     lj_gc_check(L);
 }
-
-
-static int luaByteCodewriter(lua_State *L, const void *p, size_t size,
-                             void *u)
-{
-    UNUSED(L);
-
-    utArray<unsigned char> *bytecode = (utArray<unsigned char> *)u;
-
-    unsigned char *data = (unsigned char *)p;
-    for (size_t i = 0; i < size; i++, data++)
-    {
-        bytecode->push_back(*data);
-    }
-
-    return 0;
-}
-
 
 ByteCode *JitTypeCompiler::generateByteCode(GCproto *proto, bool debug = true)
 {
@@ -305,31 +466,15 @@ void JitTypeCompiler::generateConstructor(FunctionLiteral *function,
     currentMethod = NULL;
 }
 
-
-utArray<Statement *> *JitTypeCompiler::visitStatementArray(
-    utArray<Statement *> *_statements)
-{
-    if (_statements != NULL)
-    {
-        utArray<Statement *>& statements = *_statements;
-
-        for (unsigned int i = 0; i < statements.size(); i++)
-        {
-            statements[i] = visitStatement(statements[i]);
-        }
-    }
-
-    return _statements;
-}
-
-
 Statement *JitTypeCompiler::visitStatement(Statement *statement)
 {
     if (statement != NULL)
     {
         if (statement->lineNumber)
         {
-            lineNumber = cs->lineNumber = BC::lineNumber = statement->lineNumber;
+            lineNumber     = statement->lineNumber;
+            BC::lineNumber = statement->lineNumber;
+            cs->lineNumber = statement->lineNumber;
         }
         statement = statement->visitStatement(this);
 
@@ -345,62 +490,9 @@ Statement *JitTypeCompiler::visitStatement(Statement *statement)
 }
 
 
-utArray<Expression *> *JitTypeCompiler::visitExpressionArray(
-    utArray<Expression *> *_expressions)
-{
-    if (_expressions != NULL)
-    {
-        utArray<Expression *>& expressions = *_expressions;
-
-        for (unsigned int i = 0; i < expressions.size(); i++)
-        {
-            expressions[i] = visitExpression(expressions[i]);
-        }
-    }
-
-    return _expressions;
-}
-
-
-Expression *JitTypeCompiler::visitExpression(Expression *expression)
-{
-    if (expression != NULL)
-    {
-        expression = expression->visitExpression(this);
-    }
-
-    return expression;
-}
-
-
-//
-// nodes
-//
-
-CompilationUnit *JitTypeCompiler::visit(CompilationUnit *cunit)
-{
-    return cunit;
-}
-
-
 //
 // statements
 //
-
-Statement *JitTypeCompiler::visit(FunctionDeclaration *declaration)
-{
-    lmAssert(0, "FunctionDeclaration");
-
-    return declaration;
-}
-
-
-Statement *JitTypeCompiler::visit(PropertyDeclaration *declaration)
-{
-    lmAssert(0, "PropertyDeclaration");
-
-    return declaration;
-}
 
 
 void JitTypeCompiler::chunk(utArray<Statement *> *statements)
@@ -430,15 +522,6 @@ void JitTypeCompiler::chunk(utArray<Statement *> *statements)
 
     BC::leaveLevel(cs);
 }
-
-
-Statement *JitTypeCompiler::visit(BlockStatement *statement)
-{
-    chunk(statement->statements);
-
-    return statement;
-}
-
 
 Statement *JitTypeCompiler::visit(BreakStatement *statement)
 {
@@ -532,12 +615,7 @@ Statement *JitTypeCompiler::visit(DoStatement *statement)
 
     lua_assert(bl.breaklist == NO_JMP);
 
-    //statement->expression->visitExpression(this);
-    //ExpDesc c = statement->expression->e;
-
     int condexit = encodeCondition(statement->expression);
-
-    //int condexit = BC::cond(cs, &c);
 
     BC::jmpPatch(fs, BC::emitJmp(fs), whileinit);
 
@@ -547,21 +625,6 @@ Statement *JitTypeCompiler::visit(DoStatement *statement)
 
     return statement;
 }
-
-
-Statement *JitTypeCompiler::visit(EmptyStatement *statement)
-{
-    return statement;
-}
-
-
-Statement *JitTypeCompiler::visit(ExpressionStatement *statement)
-{
-    statement->expression->visitExpression(this);
-
-    return statement;
-}
-
 
 void JitTypeCompiler::enterBlock(FuncState *fs, FuncScope *bl,
                                  int isbreakable)
@@ -611,7 +674,6 @@ Statement *JitTypeCompiler::visit(ForStatement *statement)
     if (statement->initial)
     {
         statement->initial->visitExpression(this);
-        //BC::expToNextReg(fs, &statement->initial->e);
     }
 
     whileinit = BC::getLabel(fs);
@@ -619,9 +681,6 @@ Statement *JitTypeCompiler::visit(ForStatement *statement)
     /* condition */
     if (statement->condition)
     {
-        //statement->condition->visitExpression(this);
-        //condexit = BC::cond(cs, &statement->condition->e);
-
         condexit = encodeCondition(statement->condition);
     }
     else
@@ -669,6 +728,7 @@ Statement *JitTypeCompiler::visit(ForStatement *statement)
 Statement *JitTypeCompiler::visit(ForInStatement *statement)
 {
     FuncState *fs = cs->fs;
+    int nvars = 0;
 
     char forIteratorName[256];
 
@@ -717,19 +777,10 @@ Statement *JitTypeCompiler::visit(ForInStatement *statement)
 
     BCReg base = fs->freereg + 3;
 
-    BCLine line = lineNumber;
-
-    int nvars = 0;
+    /* create control variables */
     BC::newLocalVar(cs, "(for generator)", nvars++);
     BC::newLocalVar(cs, "(for state)", nvars++);
     BC::newLocalVar(cs, "(for control)", nvars++);
-
-    bool isVector = false;
-
-    if (statement->expression->type->getFullName() == "system.Vector")
-    {
-        isVector = true;
-    }
 
     //TODO: It would be nice to have a way to iterate pairs
     if (statement->foreach)
@@ -739,6 +790,15 @@ Statement *JitTypeCompiler::visit(ForInStatement *statement)
 
     /* create declared variables */
     BC::newLocalVar(cs, vname, nvars++);
+
+    BCLine line = lineNumber;
+
+    bool isVector = false;
+
+    if (statement->expression->type->getFullName() == "system.Vector")
+    {
+        isVector = true;
+    }
 
     ExpDesc pairs;
 
@@ -877,15 +937,6 @@ Statement *JitTypeCompiler::visit(IfStatement *statement)
     return statement;
 }
 
-
-Statement *JitTypeCompiler::visit(LabelledStatement *statement)
-{
-    lmAssert(0, "LabelledStatement");
-
-    return statement;
-}
-
-
 Statement *JitTypeCompiler::visit(ReturnStatement *statement)
 {
     FuncState *fs = cs->fs;
@@ -900,7 +951,7 @@ Statement *JitTypeCompiler::visit(ReturnStatement *statement)
     else
     {
         ExpDesc e; // Receives the _last_ expression in the list.
-        BCReg   nret = expList(&e, statement->result);
+        BCReg   nret = expList(&e, statement->result, NULL);
         if (nret == 1)
         {       // Return one result.
             if (e.k == VCALL)
@@ -1073,19 +1124,6 @@ Statement *JitTypeCompiler::visit(SwitchStatement *statement)
     return statement;
 }
 
-
-Statement *JitTypeCompiler::visit(VariableStatement *statement)
-{
-    for (unsigned int i = 0; i < statement->declarations->size(); i++)
-    {
-        VariableDeclaration *d = statement->declarations->at(i);
-        d->visitExpression(this);
-    }
-
-    return statement;
-}
-
-
 void JitTypeCompiler::block(CodeState *cs, Statement *fstat)
 {
     FuncState *fs = cs->fs;
@@ -1097,7 +1135,7 @@ void JitTypeCompiler::block(CodeState *cs, Statement *fstat)
     BC::lineNumber = fstat->lineNumber;
     fstat->visitStatement(this);
 
-    //assert(bl.breaklist == NO_JUMP);
+    lmAssert(bl.breaklist == NO_JMP, "Internal Compiler Error");
     leaveBlock(fs);
 }
 
@@ -1109,10 +1147,6 @@ Statement *JitTypeCompiler::visit(WhileStatement *statement)
     FuncScope bl;
 
     start = fs->lasttarget = fs->pc;
-
-    //statement->expression->visitExpression(this);
-
-    //condexit = BC::cond(cs, &statement->expression->e);
 
     condexit = encodeCondition(statement->expression);
 
@@ -1132,42 +1166,6 @@ Statement *JitTypeCompiler::visit(WhileStatement *statement)
 
     return statement;
 }
-
-
-Statement *JitTypeCompiler::visit(WithStatement *statement)
-{
-    lmAssert(0, "WithStatement");
-    return statement;
-}
-
-
-Statement *JitTypeCompiler::visit(ClassDeclaration *statement)
-{
-    lmAssert(0, "ClassDeclaration");
-    return statement;
-}
-
-
-Statement *JitTypeCompiler::visit(InterfaceDeclaration *statement)
-{
-    lmAssert(0, "InterfaceDeclaration");
-    return statement;
-}
-
-
-Statement *JitTypeCompiler::visit(PackageDeclaration *statement)
-{
-    lmAssert(0, "PackageDeclaration");
-    return statement;
-}
-
-
-Statement *JitTypeCompiler::visit(ImportStatement *statement)
-{
-    lmAssert(0, "ImportStatement");
-    return statement;
-}
-
 
 //
 // expressions
@@ -1200,9 +1198,6 @@ void JitTypeCompiler::generatePropertySet(ExpDesc *call, Expression *value,
 
     assert(nparams == 1);
 
-    //BC::initExpDesc(call, VCALL,
-    //        BC::codeABC(fs, OP_CALL, base, nparams + 1, 2));
-
     ExpDesc args = value->e;
 
     BCIns ins;
@@ -1224,84 +1219,12 @@ void JitTypeCompiler::generatePropertySet(ExpDesc *call, Expression *value,
     fs->freereg = base + 1; /* Leave one result by default. */
 }
 
-
-Expression *JitTypeCompiler::visit(MultipleAssignmentExpression *expression)
-{
-    lmAssert(0, "MultipleAssignmentExpression");
-    return expression;
-}
-
-
-static BinOpr getassignmentopr(const Token *t)
-{
-    Tokens *tok = Tokens::getSingletonPtr();
-
-    if (t == &tok->OPERATOR_MULTIPLYASSIGNMENT)
-    {
-        return OPR_MUL;
-    }
-
-    if (t == &tok->OPERATOR_DIVIDEASSIGNMENT)
-    {
-        return OPR_DIV;
-    }
-
-    if (t == &tok->OPERATOR_PLUSASSIGNMENT)
-    {
-        return OPR_ADD;
-    }
-
-    if (t == &tok->OPERATOR_MINUSASSIGNMENT)
-    {
-        return OPR_SUB;
-    }
-
-    if (t == &tok->OPERATOR_MODULOASSIGNMENT)
-    {
-        return OPR_MOD;
-    }
-
-    return OPR_NOBINOPR;
-}
-
-
-static BitOpr getassignmentbitopr(const Token *t)
-{
-    Tokens *tok = Tokens::getSingletonPtr();
-
-    if (t == &tok->OPERATOR_BITWISEANDASSIGNMENT)
-    {
-        return OPR_LOOM_BITAND;
-    }
-
-    if (t == &tok->OPERATOR_BITWISEORASSIGNMENT)
-    {
-        return OPR_LOOM_BITOR;
-    }
-
-    if (t == &tok->OPERATOR_BITWISEXORASSIGNMENT)
-    {
-        return OPR_LOOM_BITXOR;
-    }
-
-    if (t == &tok->OPERATOR_SHIFTLEFTASSIGNMENT)
-    {
-        return OPR_LOOM_BITLSHIFT;
-    }
-
-    if (t == &tok->OPERATOR_SHIFTRIGHTASSIGNMENT)
-    {
-        return OPR_LOOM_BITRSHIFT;
-    }
-
-    return OPR_NOBITOPR;
-}
-
-
 Expression *JitTypeCompiler::visit(AssignmentOperatorExpression *expression)
 {
     Tokens *tok = Tokens::getSingletonPtr();
     BinOpr op   = getassignmentopr(expression->type);
+
+    //lmAssert(op != OPR_NOBINOPR, "Unknown bin op on AssignentOperatorExpression");
 
     Expression *eleft  = expression->leftExpression;
     Expression *eright = expression->rightExpression;
@@ -1316,7 +1239,9 @@ Expression *JitTypeCompiler::visit(AssignmentOperatorExpression *expression)
         if (mi)
         {
             lmAssert(mi->isMethod(), "Non-method operator");
+
             MethodInfo *method = (MethodInfo *)mi;
+
             lmAssert(method->isOperator(), "Non-operator method");
 
             utArray<Expression *> args;
@@ -1419,120 +1344,6 @@ Expression *JitTypeCompiler::visit(AssignmentOperatorExpression *expression)
 
     return expression;
 }
-
-
-static BinOpr getbinopr(const Token *t)
-{
-    Tokens *tok = Tokens::getSingletonPtr();
-
-    if (t == &tok->OPERATOR_PLUS)
-    {
-        return OPR_ADD;
-    }
-
-    if (t == &tok->OPERATOR_MINUS)
-    {
-        return OPR_SUB;
-    }
-
-    if (t == &tok->OPERATOR_MULTIPLY)
-    {
-        return OPR_MUL;
-    }
-
-    if (t == &tok->OPERATOR_DIVIDE)
-    {
-        return OPR_DIV;
-    }
-
-    if (t == &tok->OPERATOR_MODULO)
-    {
-        return OPR_MOD;
-    }
-
-    if (t == &tok->OPERATOR_NOTEQUAL)
-    {
-        return OPR_NE;
-    }
-
-    if (t == &tok->OPERATOR_EQUALEQUAL)
-    {
-        return OPR_EQ;
-    }
-
-    if (t == &tok->OPERATOR_LESSTHAN)
-    {
-        return OPR_LT;
-    }
-
-    if (t == &tok->OPERATOR_LESSTHANOREQUAL)
-    {
-        return OPR_LE;
-    }
-
-    if (t == &tok->OPERATOR_GREATERTHAN)
-    {
-        return OPR_GT;
-    }
-
-    if (t == &tok->OPERATOR_GREATERTHANOREQUAL)
-    {
-        return OPR_GE;
-    }
-
-    if (t == &tok->OPERATOR_LOGICALAND)
-    {
-        return OPR_AND;
-    }
-
-    if (t == &tok->OPERATOR_LOGICALOR)
-    {
-        return OPR_OR;
-    }
-
-    if (t == &tok->OPERATOR_CONCAT)
-    {
-        return OPR_CONCAT;
-    }
-
-    /*case '^': return OPR_POW;
-     * case TK_CONCAT: return OPR_CONCAT;*/
-    return OPR_NOBINOPR;
-}
-
-
-static BitOpr getbitopr(const Token *t)
-{
-    Tokens *tok = Tokens::getSingletonPtr();
-
-    if (t == &tok->OPERATOR_SHIFTLEFT)
-    {
-        return OPR_LOOM_BITLSHIFT;
-    }
-
-    if (t == &tok->OPERATOR_SHIFTRIGHT)
-    {
-        return OPR_LOOM_BITRSHIFT;
-    }
-
-    if (t == &tok->OPERATOR_BITWISEAND)
-    {
-        return OPR_LOOM_BITAND;
-    }
-
-    if (t == &tok->OPERATOR_BITWISEOR)
-    {
-        return OPR_LOOM_BITOR;
-    }
-
-    if (t == &tok->OPERATOR_BITWISEXOR)
-    {
-        return OPR_LOOM_BITXOR;
-    }
-
-    return OPR_NOBITOPR;
-}
-
 
 const char *JitTypeCompiler::getBitOpFunctionName(BitOpr b)
 {
@@ -1757,60 +1568,6 @@ Expression *JitTypeCompiler::visit(BinaryOperatorExpression *expression)
     return expression;
 }
 
-
-Expression *JitTypeCompiler::visit(CallExpression *call)
-{
-    call->function->visitExpression(this);
-
-    MethodBase *methodBase = call->methodBase;
-
-    // check whether we're calling a methodbase
-    if (methodBase)
-    {
-        lmAssert(methodBase->isMethod(), "Non-method called");
-
-        MethodInfo *method = (MethodInfo *)methodBase;
-        generateCall(&call->function->e, call->arguments, method);
-
-        call->e = call->function->e;
-    }
-    else
-    {
-        lmAssert(call->function->type, "Untyped call");
-
-        // if we're calling a delegate we need to load up the call method
-        if (call->function->type->isDelegate())
-        {
-            MethodInfo *method = (MethodInfo *)call->function->type->findMember("call");
-
-            lmAssert(method, "delegate with no call method");
-
-            ExpDesc right;
-
-            BC::initExpDesc(&right, VKNUM, 0);
-            setnumV(&right.u.nval, method->getOrdinal());
-
-
-            BC::expToNextReg(cs->fs, &call->function->e);
-            BC::expToNextReg(cs->fs, &right);
-            BC::expToVal(cs->fs, &right);
-            BC::indexed(cs->fs, &call->function->e, &right);
-
-            generateCall(&call->function->e, call->arguments, NULL);
-            call->e = call->function->e;
-        }
-        else
-        {
-            // we're directly calling a local, instance (bound), or static method of type Function
-            generateCall(&call->function->e, call->arguments, NULL);
-            call->e = call->function->e;
-        }
-    }
-
-    return call;
-}
-
-
 Expression *JitTypeCompiler::visit(ConditionalExpression *conditional)
 {
     FuncState *fs = cs->fs;
@@ -1858,189 +1615,8 @@ Expression *JitTypeCompiler::visit(ConditionalExpression *conditional)
     return conditional;
 }
 
-
-Expression *JitTypeCompiler::visit(DeleteExpression *expression)
-{
-    lmAssert(0, "DeleteExpression");
-    return expression;
-}
-
-
-Expression *JitTypeCompiler::visit(LogicalAndExpression *expression)
-{
-    return visit((BinaryOperatorExpression *)expression);
-}
-
-
-Expression *JitTypeCompiler::visit(LogicalOrExpression *expression)
-{
-    return visit((BinaryOperatorExpression *)expression);
-}
-
-
-void JitTypeCompiler::createVarArg(ExpDesc *varg,
-                                   utArray<Expression *> *arguments, int startIdx)
-{
-    char varargname[1024];
-
-    sprintf(varargname, "__ls_vararg%i", currentFunctionLiteral->curVarArgCalls++);
-    lmAssert(currentFunctionLiteral->numVarArgCalls > 0, "0 numVarArgs");
-    currentFunctionLiteral->curVarArgCalls %= currentFunctionLiteral->numVarArgCalls;
-
-    FuncState *fs = cs->fs;
-
-    int reg = fs->freereg;
-
-    ExpDesc nvector;
-    createInstance(&nvector, "system.Vector", NULL);
-
-    ExpDesc evector;
-    BC::singleVar(cs, &evector, varargname);
-    BC::storeVar(fs, &evector, &nvector);
-
-    if (!arguments || !arguments->size())
-    {
-        *varg = evector;
-        return;
-    }
-
-    // load the vector value table
-    ExpDesc vtable;
-    BC::singleVar(cs, &vtable, varargname);
-    BC::expToNextReg(fs, &vtable);
-
-    ExpDesc v;
-    BC::initExpDesc(&v, VKNUM, 0);
-    setnumV(&v.u.nval, LSINDEXVECTOR);
-
-
-    BC::expToNextReg(fs, &v);
-    BC::expToVal(fs, &v);
-    BC::indexed(fs, &vtable, &v);
-    BC::expToNextReg(fs, &vtable);
-
-    // set the length of the varargs vector
-    ExpDesc elength;
-    BC::initExpDesc(&elength, VKNUM, 0);
-    setnumV(&elength.u.nval, LSINDEXVECTORLENGTH);
-
-    BC::expToNextReg(fs, &elength);
-    BC::expToVal(fs, &elength);
-    BC::indexed(fs, &vtable, &elength);
-
-    BC::initExpDesc(&elength, VKNUM, 0);
-
-    setnumV(&elength.u.nval, arguments->size() - startIdx);
-
-    // and store
-    BC::storeVar(fs, &vtable, &elength);
-
-    utArray<Expression *> args;
-    int length = 0;
-    for (UTsize i = startIdx; i < arguments->size(); i++)
-    {
-        Expression *arg = arguments->at(i);
-
-        int restore = fs->freereg;
-
-        BC::initExpDesc(&v, VKNUM, 0);
-        setnumV(&v.u.nval, length);
-
-        BC::expToNextReg(fs, &v);
-        BC::expToVal(fs, &v);
-
-        BC::indexed(fs, &vtable, &v);
-
-        arg->visitExpression(this);
-
-        BC::storeVar(fs, &vtable, &arg->e);
-        length++;
-
-        fs->freereg = restore;
-    }
-
-    BC::singleVar(cs, &evector, varargname);
-    BC::expToNextReg(fs, &evector);
-
-
-
-    fs->freereg = reg;
-
-    BC::singleVar(cs, varg, varargname);
-}
-
-
-int JitTypeCompiler::expList(ExpDesc *e, utArray<Expression *> *expressions,
-                             MethodBase *methodBase)
-{
-    ParameterInfo *vararg = NULL;
-
-    if (methodBase)
-    {
-        vararg = methodBase->getVarArgParameter();
-    }
-
-    if (!expressions && !vararg)
-    {
-        return 0;
-    }
-
-    if (!expressions && vararg)
-    {
-        lmAssert(vararg->position == 0, "Bad position on variable args");
-        createVarArg(e, NULL, vararg->position);
-        return 1;
-    }
-
-    int count = 0;
-
-    if (expressions)
-    {
-        for (unsigned int i = 0; i < expressions->size(); i++)
-        {
-            Expression *ex = expressions->at(i);
-
-            if (vararg && (vararg->position == i))
-            {
-                if (i)
-                {
-                    BC::expToNextReg(cs->fs, e);
-                }
-
-                createVarArg(e, expressions, vararg->position);
-                count++;
-                return count;
-            }
-
-            ex->visitExpression(this);
-
-            if (i != expressions->size() - 1)
-            {
-                BC::expToNextReg(cs->fs, &ex->e);
-            }
-
-            *e = ex->e;
-            count++;
-        }
-    }
-
-    if (vararg)
-    {
-        if (expressions && expressions->size())
-        {
-            BC::expToNextReg(cs->fs, e);
-        }
-
-        createVarArg(e, expressions, vararg->position);
-        count++;
-    }
-
-    return count;
-}
-
-
-void JitTypeCompiler::generateCall(ExpDesc *call,
-                                   utArray<Expression *> *arguments, MethodBase *methodBase)
+void JitTypeCompiler::generateCall(ExpDesc *call, utArray<Expression *> *arguments,
+                                MethodBase *methodBase)
 {
     FuncState *fs = cs->fs;
 
@@ -2073,7 +1649,7 @@ void JitTypeCompiler::generateCall(ExpDesc *call,
 
     lua_assert(call->k == VNONRELOC);
     BCIns ins;
-    BCReg base = call->u.s.info; /* Base register for call. */
+    BCReg base = call->u.s.info; /* base register for call. */
     if (args.k == VCALL)
     {
         ins = BCINS_ABC(BC_CALLM, base, 2, args.u.s.aux - base - 1);
@@ -2082,7 +1658,7 @@ void JitTypeCompiler::generateCall(ExpDesc *call,
     {
         if (args.k != VVOID)
         {
-            BC::expToNextReg(fs, &args);
+            BC::expToNextReg(fs, &args); /* close last argument */
         }
         ins = BCINS_ABC(BC_CALL, base, 2, fs->freereg - base);
     }
@@ -2091,40 +1667,6 @@ void JitTypeCompiler::generateCall(ExpDesc *call,
     fs->bcbase[fs->pc - 1].line = line;
     fs->freereg = base + 1; /* Leave one result by default. */
 }
-
-
-Expression *JitTypeCompiler::visit(NewExpression *expression)
-{
-    FuncState *fs = cs->fs;
-
-    Type *type = expression->function->type;
-
-    lmAssert(type, "Untyped new expression");
-
-    ExpDesc e;
-    createInstance(&e, type->getFullName(),
-                   expression->arguments);
-
-    if ((expression->function->astType == AST_VECTORLITERAL) || (expression->function->astType == AST_DICTIONARYLITERAL))
-    {
-        // assign new instance
-        expression->function->e = e;
-
-        BC::expToNextReg(fs, &e);
-
-        int restore = fs->freereg;
-
-        // visit literal
-        expression->function->visitExpression(this);
-
-        fs->freereg = restore;
-    }
-
-    expression->e = e;
-
-    return expression;
-}
-
 
 Expression *JitTypeCompiler::visit(UnaryOperatorExpression *expression)
 {
@@ -2182,216 +1724,6 @@ Expression *JitTypeCompiler::visit(UnaryOperatorExpression *expression)
 
     return expression;
 }
-
-
-Expression *JitTypeCompiler::visit(VariableExpression *expression)
-{
-    for (UTsize i = 0; i < expression->declarations->size(); i++)
-    {
-        VariableDeclaration *v = expression->declarations->at(i);
-        v->visitExpression(this);
-        //BC::expToNextReg(cs->fs, &v->identifier->e);
-        expression->e = v->identifier->e;
-    }
-
-    return expression;
-}
-
-
-Expression *JitTypeCompiler::visit(SuperExpression *expression)
-{
-    lmAssert(currentMethod, "Super call outside of method");
-
-    Type *type     = currentMethod->getDeclaringType();
-    Type *baseType = type->getBaseType();
-
-    //FIXME:  issue a warning
-    if (!baseType)
-    {
-        return expression;
-    }
-
-    FuncState *fs = cs->fs;
-
-    if (currentMethod->isConstructor())
-    {
-        ConstructorInfo *base = baseType->getConstructor();
-
-        //FIXME: warn if no base constructor
-        if (!base)
-        {
-            return expression;
-        }
-
-        // load up base class
-        ExpDesc eclass;
-        BC::singleVar(cs, &eclass, baseType->getFullName().c_str());
-
-        // index with the __ls_constructor
-        BC::expToNextReg(fs, &eclass);
-
-        ExpDesc fname;
-        BC::expString(cs, &fname, "__ls_constructor");
-
-        BC::expToNextReg(fs, &fname);
-        BC::expToVal(fs, &fname);
-        BC::indexed(fs, &eclass, &fname);
-
-        // call the LSMethod
-        generateCall(&eclass, &expression->arguments);
-    }
-    else
-    {
-        utString name = currentMethod->getName();
-
-        if (expression->method)
-        {
-            name = expression->method->string;
-        }
-
-        MemberInfo *mi = baseType->findMember(name.c_str());
-        //FIXME: warn
-        if (!mi)
-        {
-            return expression;
-        }
-
-        lmAssert(mi->isMethod(), "super call on non-method");
-
-        MethodInfo *methodInfo = (MethodInfo *)mi;
-
-        // load up declaring class
-        ExpDesc eclass;
-        BC::singleVar(cs, &eclass,
-                      methodInfo->getDeclaringType()->getFullName().c_str());
-
-        BC::expToNextReg(fs, &eclass);
-
-        ExpDesc fname;
-        BC::expString(cs, &fname, name.c_str());
-
-        BC::expToNextReg(fs, &fname);
-        BC::expToVal(fs, &fname);
-        BC::indexed(fs, &eclass, &fname);
-
-        // call the LSMethod
-        generateCall(&eclass, &expression->arguments);
-
-        expression->e = eclass;
-    }
-
-    return expression;
-}
-
-
-Expression *JitTypeCompiler::visit(VariableDeclaration *declaration)
-{
-    FuncState *fs = cs->fs;
-
-    // local variable declaration
-    lmAssert(!declaration->classDecl, "Local variable belongs to class");
-
-    ExpDesc v;
-    BC::singleVar(cs, &v, declaration->identifier->string.c_str());
-
-    Type       *dt     = declaration->type;
-    MethodInfo *method = NULL;
-    method = (MethodInfo *)dt->findMember("__op_assignment");
-
-    //TODO: assignment overload in default args?
-    if (declaration->isParameter)
-    {
-        method = NULL;
-    }
-
-    if (method)
-    {
-        if (dt->isStruct())
-        {
-            generateVarDeclStruct(declaration);
-        }
-        else if (dt->isDelegate())
-        {
-            generateVarDeclDelegate(declaration);
-        }
-        else
-        {
-            lmAssert(0, "unexpected __op_assignment on non delegate or struct");
-        }
-
-        return declaration;
-    }
-
-    else
-    {
-        lmAssert(!dt->isDelegate() && !dt->isStruct(),
-                 "unexpected delegate/struct");
-
-        fs->freereg = fs->nactvar; /* free registers */
-        declaration->identifier->visitExpression(this);
-        declaration->initializer->visitExpression(this);
-        BC::storeVar(fs, &declaration->identifier->e,
-                     &declaration->initializer->e);
-    }
-
-    return declaration;
-}
-
-
-//
-// literals
-//
-
-Expression *JitTypeCompiler::visit(ThisLiteral *literal)
-{
-    BC::singleVar(cs, &literal->e, "this");
-
-    return literal;
-}
-
-
-Expression *JitTypeCompiler::visit(NullLiteral *literal)
-{
-    BC::initExpDesc(&literal->e, VKNIL, 0);
-
-    return literal;
-}
-
-
-Expression *JitTypeCompiler::visit(BooleanLiteral *literal)
-{
-    if (literal->value)
-    {
-        BC::initExpDesc(&literal->e, VKTRUE, 0);
-    }
-    else
-    {
-        BC::initExpDesc(&literal->e, VKFALSE, 0);
-    }
-
-    return literal;
-}
-
-
-Expression *JitTypeCompiler::visit(NumberLiteral *literal)
-{
-    ExpDesc e;
-    BC::initExpDesc(&e, VKNUM, 0);
-
-    setnumV(&e.u.nval, literal->value);
-
-    literal->e = e;
-
-    return literal;
-}
-
-
-Expression *JitTypeCompiler::visit(ArrayLiteral *literal)
-{
-    lmAssert(0, "ArrayLiteral");
-    return literal;
-}
-
 
 void JitTypeCompiler::functionBody(ExpDesc *e, FunctionLiteral *flit,
                                    int line)
@@ -2455,7 +1787,7 @@ Expression *JitTypeCompiler::visit(FunctionLiteral *literal)
     inLocalFunction++;
 
     char funcname[256];
-    sprintf(funcname, "__ls_localfunction%i", functioncount++);
+    snprintf(funcname, 250, "__ls_localfunction%i", functioncount++);
 
     ExpDesc   v, b;
     FuncState *fs = cs->fs;
@@ -2516,61 +1848,6 @@ Expression *JitTypeCompiler::visit(FunctionLiteral *literal)
 
     return literal;
 }
-
-
-Expression *JitTypeCompiler::visit(ObjectLiteral *literal)
-{
-    lmAssert(0, "ObjectLiteral");
-    return literal;
-}
-
-
-Expression *JitTypeCompiler::visit(ObjectLiteralProperty *property)
-{
-    lmAssert(0, "ObjectLiteralProperty");
-    return property;
-}
-
-
-Expression *JitTypeCompiler::visit(PropertyLiteral *property)
-{
-    lmAssert(0, "PropertyLiteral");
-    return property;
-}
-
-
-Expression *JitTypeCompiler::visit(DictionaryLiteralPair *pair)
-{
-    return pair;
-}
-
-
-Expression *JitTypeCompiler::visit(DictionaryLiteral *literal)
-{
-    FuncState *fs = cs->fs;
-
-    for (UTsize i = 0; i < literal->pairs.size(); i++)
-    {
-        DictionaryLiteralPair *pair = literal->pairs[i];
-
-        // comes in from NewExpression visitor
-        ExpDesc ethis = literal->e;
-
-        BC::expToNextReg(fs, &ethis);
-
-        pair->key->visitExpression(this);
-
-        BC::expToNextReg(fs, &pair->key->e);
-        BC::expToVal(fs, &pair->key->e);
-        BC::indexed(fs, &ethis, &pair->key->e);
-
-        pair->value->visitExpression(this);
-        BC::storeVar(fs, &ethis, &pair->value->e);
-    }
-
-    return literal;
-}
-
 
 bool JitTypeCompiler::castBool(Expression *expr, ExpDesc *e)
 {

--- a/loom/script/compiler/lsJitTypeCompiler.h
+++ b/loom/script/compiler/lsJitTypeCompiler.h
@@ -58,8 +58,7 @@ class JitTypeCompiler : public TypeCompilerBase {
     void functionBody(ExpDesc *e, FunctionLiteral *flit, int line);
 
     int parList(FunctionLiteral *literal, bool method);
-    int expList(ExpDesc *e, utArray<Expression *> *expressions,
-                MethodBase *methodBase = NULL);
+
     void generateCall(ExpDesc *call, utArray<Expression *> *arguments,
                       MethodBase *methodBase = NULL);
 
@@ -90,31 +89,11 @@ public:
 
     static void compile(ClassDeclaration *classDeclaration);
 
-    utArray<Statement *> *visitStatementArray(
-        utArray<Statement *> *_statements);
-
     Statement *visitStatement(Statement *statement);
-
-    utArray<Expression *> *visitExpressionArray(
-        utArray<Expression *> *_expressions);
-
-    Expression *visitExpression(Expression *expression);
-
-    //
-    // nodes
-    //
-
-    CompilationUnit *visit(CompilationUnit *cunit);
 
     //
     // statements
     //
-
-    Statement *visit(FunctionDeclaration *declaration);
-
-    Statement *visit(PropertyDeclaration *declaration);
-
-    Statement *visit(BlockStatement *statement);
 
     Statement *visit(BreakStatement *statement);
 
@@ -124,91 +103,36 @@ public:
 
     Statement *visit(DoStatement *statement);
 
-    Statement *visit(EmptyStatement *statement);
-
-    Statement *visit(ExpressionStatement *statement);
-
     Statement *visit(ForStatement *statement);
 
     Statement *visit(ForInStatement *statement);
 
     Statement *visit(IfStatement *statement);
 
-    Statement *visit(LabelledStatement *statement);
-
     Statement *visit(ReturnStatement *statement);
 
     Statement *visit(SwitchStatement *statement);
 
-    Statement *visit(VariableStatement *statement);
-
     Statement *visit(WhileStatement *statement);
-
-    Statement *visit(WithStatement *statement);
-
-    Statement *visit(ClassDeclaration *statement);
-
-    Statement *visit(InterfaceDeclaration *statement);
-
-    Statement *visit(PackageDeclaration *statement);
-
-    Statement *visit(ImportStatement *statement);
 
     //
     // expressions
     //
 
-    Expression *visit(MultipleAssignmentExpression *expression);
-
     Expression *visit(AssignmentOperatorExpression *expression);
 
     Expression *visit(BinaryOperatorExpression *expression);
 
-    Expression *visit(CallExpression *expression);
-
     Expression *visit(ConditionalExpression *expression);
 
-    Expression *visit(DeleteExpression *expression);
-
-    Expression *visit(LogicalAndExpression *expression);
-
-    Expression *visit(LogicalOrExpression *expression);
-
-    Expression *visit(NewExpression *expression);
-
     Expression *visit(UnaryOperatorExpression *expression);
-
-    Expression *visit(VariableExpression *expression);
-
-    Expression *visit(SuperExpression *expression);
-
-    Expression *visit(VariableDeclaration *declaration);
 
     //
     // literals
     //
 
-    Expression *visit(ThisLiteral *literal);
-
-    Expression *visit(NullLiteral *literal);
-
-    Expression *visit(BooleanLiteral *literal);
-
-    Expression *visit(NumberLiteral *literal);
-
-    Expression *visit(ArrayLiteral *literal);
-
     Expression *visit(FunctionLiteral *literal);
 
-    Expression *visit(ObjectLiteral *literal);
-
-    Expression *visit(ObjectLiteralProperty *property);
-
-    Expression *visit(PropertyLiteral *property);
-
-    Expression *visit(DictionaryLiteralPair *pair);
-
-    Expression *visit(DictionaryLiteral *literal);
 };
 }
 #endif //LOOM_ENABLE_JIT

--- a/loom/script/compiler/lsTypeCompiler.cpp
+++ b/loom/script/compiler/lsTypeCompiler.cpp
@@ -44,7 +44,18 @@ extern "C" {
 #include "loom/script/common/lsLog.h"
 #include "loom/script/runtime/lsRuntime.h"
 
+// Compatibility to keep code similar with JIT paths.
 #define setnumV(var, val) *(var) = val;
+
+// Enable this to get verbose logging about automatic super call generation.
+//#define DEBUG_CONSTRUCTORS
+
+#ifdef DEBUG_CONSTRUCTORS
+#   define CTOR_LOG(...) printf(__VA_ARGS__);
+#else
+#   define CTOR_LOG(...)
+#endif
+
 
 namespace LS {
 
@@ -436,7 +447,7 @@ void TypeCompiler::generateConstructor(FunctionLiteral *function,
        || constructor->getDeclaringType()->getBaseType()->getFullName() == "system.Object")
         skipSuper = true;
 
-    //printf("Considering super for %s\n", constructor->getDeclaringType()->getFullName().c_str());
+    CTOR_LOG("Considering super for %s\n", constructor->getDeclaringType()->getFullName().c_str());
 
     // If there is no super call in this method, add it at the start so we
     // always fully initialize the class - otherwise we have to traverse
@@ -447,9 +458,9 @@ void TypeCompiler::generateConstructor(FunctionLiteral *function,
        && skipSuper == false
        && constructor->getDeclaringType()->isPrimitive() == false)
     {
-        //printf("Generating super call to %s in constructor of %s\n",
-        //       constructor->getDeclaringType()->getBaseType() ? constructor->getDeclaringType()->getBaseType()->getFullName().c_str() : "(none)",
-        //       constructor->getDeclaringType()->getFullName().c_str());
+        CTOR_LOG("Generating super call to %s in constructor of %s\n",
+               constructor->getDeclaringType()->getBaseType() ? constructor->getDeclaringType()->getBaseType()->getFullName().c_str() : "(none)",
+               constructor->getDeclaringType()->getFullName().c_str());
 
         // We want to insert a call to super(); if none is present. We need
         // to pass "this" so it has an instance to operate on.

--- a/loom/script/compiler/lsTypeCompiler.cpp
+++ b/loom/script/compiler/lsTypeCompiler.cpp
@@ -431,6 +431,8 @@ void TypeCompiler::generateConstructor(FunctionLiteral *function,
     if(constructor->getDeclaringType() == NULL
        || constructor->getDeclaringType()->getBaseType() == NULL
        || constructor->getDeclaringType()->getBaseType()->isInterface()
+       || (constructor->getDeclaringType()->getBaseType()->getConstructor()->isNative()
+           && constructor->getDeclaringType()->getBaseType()->getFullName() != "system.BaseDelegate")
        || constructor->getDeclaringType()->getBaseType()->getFullName() == "system.Object")
         skipSuper = true;
 

--- a/loom/script/compiler/lsTypeCompiler.cpp
+++ b/loom/script/compiler/lsTypeCompiler.cpp
@@ -430,8 +430,6 @@ void TypeCompiler::generateConstructor(FunctionLiteral *function,
 
     if(constructor->getDeclaringType() == NULL
        || constructor->getDeclaringType()->getBaseType() == NULL
-       || constructor->getDeclaringType()->getBaseType()->isNativeManaged()
-       || constructor->getDeclaringType()->getBaseType()->isNative()
        || constructor->getDeclaringType()->getBaseType()->isInterface()
        || constructor->getDeclaringType()->getBaseType()->getFullName() == "system.Object")
         skipSuper = true;

--- a/loom/script/compiler/lsTypeCompiler.cpp
+++ b/loom/script/compiler/lsTypeCompiler.cpp
@@ -426,11 +426,17 @@ void TypeCompiler::generateConstructor(FunctionLiteral *function,
 
     // We don't want to call super if it's a native type, as this is handled
     // at runtime.
-    bool isSuperNative = false;
-    if(constructor->getDeclaringType() != NULL
-       && constructor->getDeclaringType()->getBaseType()
-       && constructor->getDeclaringType()->getBaseType()->isNative())
-        isSuperNative = true;
+    bool skipSuper = false;
+
+    if(constructor->getDeclaringType() == NULL
+       || constructor->getDeclaringType()->getBaseType() == NULL
+       || constructor->getDeclaringType()->getBaseType()->isNativeManaged()
+       || constructor->getDeclaringType()->getBaseType()->isNative()
+       || constructor->getDeclaringType()->getBaseType()->isInterface()
+       || constructor->getDeclaringType()->getBaseType()->getFullName() == "system.Object")
+        skipSuper = true;
+
+    //printf("Considering super for %s\n", constructor->getDeclaringType()->getFullName().c_str());
 
     // If there is no super call in this method, add it at the start so we
     // always fully initialize the class - otherwise we have to traverse
@@ -438,9 +444,13 @@ void TypeCompiler::generateConstructor(FunctionLiteral *function,
     if(function->isConstructor
        && function->hasSuperCall == false
        && function->isNative == false
-       && !isSuperNative
+       && skipSuper == false
        && constructor->getDeclaringType()->isPrimitive() == false)
     {
+        //printf("Generating super call to %s in constructor of %s\n",
+        //       constructor->getDeclaringType()->getBaseType() ? constructor->getDeclaringType()->getBaseType()->getFullName().c_str() : "(none)",
+        //       constructor->getDeclaringType()->getFullName().c_str());
+
         // We want to insert a call to super(); if none is present. We need
         // to pass "this" so it has an instance to operate on.
         SuperExpression *expr = new SuperExpression();
@@ -459,12 +469,10 @@ void TypeCompiler::generateConstructor(FunctionLiteral *function,
     closeCodeState(&codeState);
 
 	bool debug = cunit->buildInfo->isDebugBuild();
-
     constructor->setByteCode(generateByteCode(funcState.f, debug));
 
     currentMethod = NULL;
 }
-
 
 
 Statement *TypeCompiler::visitStatement(Statement *statement)

--- a/loom/script/compiler/lsTypeCompiler.h
+++ b/loom/script/compiler/lsTypeCompiler.h
@@ -35,8 +35,6 @@
 
 namespace LS {
 class TypeCompiler : public TypeCompilerBase  {
-    int expList(ExpDesc *e, utArray<Expression *> *expressions,
-                MethodBase *methodBase = NULL);
 
     int parList(FunctionLiteral *function, bool method);
 
@@ -73,31 +71,11 @@ public:
 
     static void compile(ClassDeclaration *classDeclaration);
 
-    utArray<Statement *> *visitStatementArray(
-        utArray<Statement *> *_statements);
-
     Statement *visitStatement(Statement *statement);
-
-    utArray<Expression *> *visitExpressionArray(
-        utArray<Expression *> *_expressions);
-
-    Expression *visitExpression(Expression *expression);
-
-    //
-    // nodes
-    //
-
-    CompilationUnit *visit(CompilationUnit *cunit);
 
     //
     // statements
     //
-
-    Statement *visit(FunctionDeclaration *declaration);
-
-    Statement *visit(PropertyDeclaration *declaration);
-
-    Statement *visit(BlockStatement *statement);
 
     Statement *visit(BreakStatement *statement);
 
@@ -107,92 +85,36 @@ public:
 
     Statement *visit(DoStatement *statement);
 
-    Statement *visit(EmptyStatement *statement);
-
-    Statement *visit(ExpressionStatement *statement);
-
     Statement *visit(ForStatement *statement);
 
     Statement *visit(ForInStatement *statement);
 
     Statement *visit(IfStatement *statement);
 
-    Statement *visit(LabelledStatement *statement);
-
     Statement *visit(ReturnStatement *statement);
 
     Statement *visit(SwitchStatement *statement);
 
-    Statement *visit(VariableStatement *statement);
-
     Statement *visit(WhileStatement *statement);
-
-    Statement *visit(WithStatement *statement);
-
-    Statement *visit(ClassDeclaration *statement);
-
-    Statement *visit(InterfaceDeclaration *statement);
-
-    Statement *visit(PackageDeclaration *statement);
-
-    Statement *visit(ImportStatement *statement);
 
     //
     // expressions
     //
 
-    Expression *visit(MultipleAssignmentExpression *expression);
-
     Expression *visit(AssignmentOperatorExpression *expression);
 
     Expression *visit(BinaryOperatorExpression *expression);
 
-    Expression *visit(CallExpression *expression);
-
     Expression *visit(ConditionalExpression *expression);
 
-    Expression *visit(DeleteExpression *expression);
-
-    Expression *visit(LogicalAndExpression *expression);
-
-    Expression *visit(LogicalOrExpression *expression);
-
-    Expression *visit(NewExpression *expression);
-
     Expression *visit(UnaryOperatorExpression *expression);
-
-    Expression *visit(VariableExpression *expression);
-
-    Expression *visit(SuperExpression *expression);
-
-    Expression *visit(VariableDeclaration *declaration);
 
     //
     // literals
     //
 
 
-    Expression *visit(ThisLiteral *literal);
-
-    Expression *visit(NullLiteral *literal);
-
-    Expression *visit(BooleanLiteral *literal);
-
-    Expression *visit(NumberLiteral *literal);
-
-    Expression *visit(ArrayLiteral *literal);
-
     Expression *visit(FunctionLiteral *literal);
-
-    Expression *visit(ObjectLiteral *literal);
-
-    Expression *visit(ObjectLiteralProperty *property);
-
-    Expression *visit(PropertyLiteral *property);
-
-    Expression *visit(DictionaryLiteralPair *pair);
-
-    Expression *visit(DictionaryLiteral *literal);
 };
 }
 #endif //LOOM_ENABLE_JIT

--- a/loom/script/compiler/lsTypeCompilerBase.cpp
+++ b/loom/script/compiler/lsTypeCompilerBase.cpp
@@ -35,6 +35,23 @@ extern "C" {
 #endif
 
 namespace LS  {
+
+int TypeCompilerBase::luaByteCodewriter(lua_State *L, const void *p, size_t size,
+                             void *u)
+{
+    UNUSED(L);
+
+    utArray<unsigned char> *bytecode = (utArray<unsigned char> *)u;
+
+    unsigned char *data = (unsigned char *)p;
+    for (size_t i = 0; i < size; i++, data++)
+    {
+        bytecode->push_back(*data);
+    }
+    
+    return 0;
+}
+
 void TypeCompilerBase::_compile()
 {
     vm    = cls->type->getModule()->getAssembly()->getLuaState();
@@ -128,8 +145,7 @@ void TypeCompilerBase::_compile()
 }
 
 
-void TypeCompilerBase::generateIdentifierTypeConversion(
-    Identifier *identifier)
+void TypeCompilerBase::generateIdentifierTypeConversion(Identifier *identifier)
 {
     // We're a Type, so we need to query reflection
 
@@ -153,11 +169,661 @@ void TypeCompilerBase::generateIdentifierTypeConversion(
     identifier->e = opcall;
 
     generateCall(&identifier->e, &args,
-                 (MethodBase *)vm->getType("system.reflection.Type")->findMember(
-                     "getTypeByName"));
+                 (MethodBase *)vm->getType("system.reflection.Type")->findMember("getTypeByName"));
 
     // we're done with our expression, so delete it
     delete (StringLiteral *)args[0];
+}
+
+utArray<Statement *> *TypeCompilerBase::visitStatementArray(utArray<Statement *> *_statements)
+{
+    if (_statements != NULL)
+    {
+        utArray<Statement *>& statements = *_statements;
+
+        for (unsigned int i = 0; i < statements.size(); i++)
+        {
+            statements[i] = visitStatement(statements[i]);
+        }
+    }
+    
+    return _statements;
+}
+
+utArray<Expression *> *TypeCompilerBase::visitExpressionArray(utArray<Expression *> *_expressions)
+{
+    if (_expressions != NULL)
+    {
+        utArray<Expression *>& expressions = *_expressions;
+
+        for (unsigned int i = 0; i < expressions.size(); i++)
+        {
+            expressions[i] = visitExpression(expressions[i]);
+        }
+    }
+
+    return _expressions;
+}
+
+
+Expression *TypeCompilerBase::visitExpression(Expression *expression)
+{
+    if (expression != NULL)
+    {
+        expression = expression->visitExpression(this);
+    }
+    
+    return expression;
+}
+
+CompilationUnit *TypeCompilerBase::visit(CompilationUnit *cunit)
+{
+    return cunit;
+}
+
+Statement *TypeCompilerBase::visit(FunctionDeclaration *declaration)
+{
+    lmAssert(0, "FunctionDeclaration");
+
+    return declaration;
+}
+
+
+Statement *TypeCompilerBase::visit(PropertyDeclaration *declaration)
+{
+    lmAssert(0, "PropertyDeclaration");
+    
+    return declaration;
+}
+
+Statement *TypeCompilerBase::visit(BlockStatement *statement)
+{
+    chunk(statement->statements);
+
+    return statement;
+}
+
+Statement *TypeCompilerBase::visit(EmptyStatement *statement)
+{
+    return statement;
+}
+
+
+Statement *TypeCompilerBase::visit(ExpressionStatement *statement)
+{
+    statement->expression->visitExpression(this);
+    
+    return statement;
+}
+
+Statement *TypeCompilerBase::visit(LabelledStatement *statement)
+{
+    lmAssert(0, "LabelledStatement");
+
+    return statement;
+}
+
+Statement *TypeCompilerBase::visit(VariableStatement *statement)
+{
+    for (unsigned int i = 0; i < statement->declarations->size(); i++)
+    {
+        VariableDeclaration *d = statement->declarations->at(i);
+        d->visitExpression(this);
+    }
+
+    return statement;
+}
+
+Statement *TypeCompilerBase::visit(WithStatement *statement)
+{
+    lmAssert(0, "WithStatement");
+    return statement;
+}
+
+
+Statement *TypeCompilerBase::visit(ClassDeclaration *statement)
+{
+    lmAssert(0, "ClassDeclaration");
+    return statement;
+}
+
+
+Statement *TypeCompilerBase::visit(InterfaceDeclaration *statement)
+{
+    lmAssert(0, "InterfaceDeclaration");
+    return statement;
+}
+
+
+Statement *TypeCompilerBase::visit(PackageDeclaration *statement)
+{
+    lmAssert(0, "PackageDeclaration");
+    return statement;
+}
+
+
+Statement *TypeCompilerBase::visit(ImportStatement *statement)
+{
+    lmAssert(0, "ImportStatement");
+    return statement;
+}
+
+Expression *TypeCompilerBase::visit(MultipleAssignmentExpression *expression)
+{
+    lmAssert(0, "MultipleAssignmentExpression");
+    return expression;
+}
+
+Expression *TypeCompilerBase::visit(DeleteExpression *expression)
+{
+    lmAssert(0, "DeleteExpression");
+    return expression;
+}
+
+Expression *TypeCompilerBase::visit(LogicalAndExpression *expression)
+{
+    return visit((BinaryOperatorExpression *)expression);
+}
+
+Expression *TypeCompilerBase::visit(LogicalOrExpression *expression)
+{
+    return visit((BinaryOperatorExpression *)expression);
+}
+
+Expression *TypeCompilerBase::visit(CallExpression *call)
+{
+    MethodBase *methodBase = call->methodBase;
+
+    call->function->visitExpression(this);
+
+    // check whether we're calling a methodbase
+    if (methodBase)
+    {
+        lmAssert(methodBase->isMethod(), "Non-method called");
+
+        MethodInfo *method = (MethodInfo *)methodBase;
+        generateCall(&call->function->e, call->arguments, method);
+
+        call->e = call->function->e;
+    }
+    else
+    {
+        lmAssert(call->function->type, "Untyped call");
+
+        // if we're calling a delegate we need to load up the call method
+        if (call->function->type->isDelegate())
+        {
+            MethodInfo *method = (MethodInfo *)call->function->type->findMember("call");
+
+            lmAssert(method, "delegate with no call method");
+
+            ExpDesc right;
+
+            BC::initExpDesc(&right, VKNUM, 0);
+            setnumV(&right.u.nval, method->getOrdinal());
+
+
+            BC::expToNextReg(cs->fs, &call->function->e);
+            BC::expToNextReg(cs->fs, &right);
+            BC::expToVal(cs->fs, &right);
+            BC::indexed(cs->fs, &call->function->e, &right);
+
+            generateCall(&call->function->e, call->arguments, NULL);
+            call->e = call->function->e;
+        }
+        else
+        {
+            // we're directly calling a local, instance (bound), or static method of type Function
+            generateCall(&call->function->e, call->arguments, NULL);
+            call->e = call->function->e;
+        }
+    }
+    
+    return call;
+}
+
+
+void TypeCompilerBase::createVarArg(ExpDesc *varg, utArray<Expression *> *arguments,
+                                   int startIdx)
+{
+    char varargname[1024];
+
+    sprintf(varargname, "__ls_vararg%i", currentFunctionLiteral->curVarArgCalls++);
+    lmAssert(currentFunctionLiteral->numVarArgCalls > 0, "0 numVarArgs");
+    currentFunctionLiteral->curVarArgCalls %= currentFunctionLiteral->numVarArgCalls;
+
+    FuncState *fs = cs->fs;
+
+    int reg = fs->freereg;
+
+    ExpDesc nvector;
+    createInstance(&nvector, "system.Vector", NULL);
+
+    ExpDesc evector;
+    BC::singleVar(cs, &evector, varargname);
+    BC::storeVar(fs, &evector, &nvector);
+
+    if (!arguments || !arguments->size())
+    {
+        *varg = evector;
+        return;
+    }
+
+    // load the vector value table
+    ExpDesc vtable;
+    BC::singleVar(cs, &vtable, varargname);
+    BC::expToNextReg(fs, &vtable);
+
+    ExpDesc v;
+    BC::initExpDesc(&v, VKNUM, 0);
+    setnumV(&v.u.nval, LSINDEXVECTOR);
+
+    BC::expToNextReg(fs, &v);
+    BC::expToVal(fs, &v);
+    BC::indexed(fs, &vtable, &v);
+    BC::expToNextReg(fs, &vtable);
+
+    // set the length of the varargs vector
+    ExpDesc elength;
+    BC::initExpDesc(&elength, VKNUM, 0);
+    setnumV(&elength.u.nval, LSINDEXVECTORLENGTH);
+
+    BC::expToNextReg(fs, &elength);
+    BC::expToVal(fs, &elength);
+    BC::indexed(fs, &vtable, &elength);
+
+    BC::initExpDesc(&elength, VKNUM, 0);
+
+    setnumV(&elength.u.nval, arguments->size() - startIdx);
+
+    // and store
+    BC::storeVar(fs, &vtable, &elength);
+
+    utArray<Expression *> args;
+    int length = 0;
+    for (UTsize i = startIdx; i < arguments->size(); i++)
+    {
+        Expression *arg = arguments->at(i);
+
+        int restore = fs->freereg;
+
+        BC::initExpDesc(&v, VKNUM, 0);
+        setnumV(&v.u.nval, length);
+
+        BC::expToNextReg(fs, &v);
+        BC::expToVal(fs, &v);
+
+        BC::indexed(fs, &vtable, &v);
+
+        arg->visitExpression(this);
+
+        BC::storeVar(fs, &vtable, &arg->e);
+        length++;
+
+        fs->freereg = restore;
+    }
+
+    BC::singleVar(cs, &evector, varargname);
+    BC::expToNextReg(fs, &evector);
+
+    fs->freereg = reg;
+
+    BC::singleVar(cs, varg, varargname);
+}
+
+int TypeCompilerBase::expList(ExpDesc *e, utArray<Expression *> *expressions,
+                             MethodBase *methodBase)
+{
+    ParameterInfo *vararg = NULL;
+
+    if (methodBase)
+    {
+        vararg = methodBase->getVarArgParameter();
+    }
+
+    if (!expressions && !vararg)
+    {
+        return 0;
+    }
+
+    if (!expressions && vararg)
+    {
+        lmAssert(vararg->position == 0, "Bad position on variable args");
+        createVarArg(e, NULL, vararg->position);
+        return 1;
+    }
+
+    int count = 0;
+
+    if (expressions)
+    {
+        for (unsigned int i = 0; i < expressions->size(); i++)
+        {
+            Expression *ex = expressions->at(i);
+
+            if (vararg && (vararg->position == i))
+            {
+                if (i)
+                {
+                    BC::expToNextReg(cs->fs, e);
+                }
+                
+                createVarArg(e, expressions, vararg->position);
+                count++;
+                return count;
+            }
+            
+            ex->visitExpression(this);
+            
+            if (i != expressions->size() - 1)
+            {
+                BC::expToNextReg(cs->fs, &ex->e);
+            }
+            
+            *e = ex->e;
+            count++;
+        }
+    }
+    
+    if (vararg)
+    {
+        if (expressions && expressions->size())
+        {
+            BC::expToNextReg(cs->fs, e);
+        }
+        
+        createVarArg(e, expressions, vararg->position);
+        count++;
+    }
+    
+    return count;
+}
+
+Expression *TypeCompilerBase::visit(NewExpression *expression)
+{
+    FuncState *fs = cs->fs;
+
+    Type *type = expression->function->type;
+
+    lmAssert(type, "Untyped new expression");
+
+    ExpDesc e;
+    createInstance(&e, type->getFullName(), expression->arguments);
+
+    if ((expression->function->astType == AST_VECTORLITERAL) || (expression->function->astType == AST_DICTIONARYLITERAL))
+    {
+        // assign new instance
+        expression->function->e = e;
+
+        BC::expToNextReg(fs, &e);
+
+        int restore = fs->freereg;
+
+        // visit literal
+        expression->function->visitExpression(this);
+        
+        fs->freereg = restore;
+    }
+    
+    expression->e = e;
+    
+    return expression;
+}
+
+
+Expression *TypeCompilerBase::visit(VariableExpression *expression)
+{
+    for (UTsize i = 0; i < expression->declarations->size(); i++)
+    {
+        VariableDeclaration *v = expression->declarations->at(i);
+        v->visitExpression(this);
+        expression->e = v->identifier->e;
+    }
+
+    return expression;
+}
+
+Expression *TypeCompilerBase::visit(SuperExpression *expression)
+{
+    lmAssert(currentMethod, "Super call outside of method");
+
+    Type *type     = currentMethod->getDeclaringType();
+    Type *baseType = type->getBaseType();
+
+    //FIXME:  issue a warning
+    if (!baseType)
+    {
+        return expression;
+    }
+
+    FuncState *fs = cs->fs;
+
+    if (currentMethod->isConstructor())
+    {
+        ConstructorInfo *base = baseType->getConstructor();
+
+        //FIXME: warn if no base constructor
+        if (!base)
+        {
+            return expression;
+        }
+
+        // load up base class
+        ExpDesc eclass;
+        BC::singleVar(cs, &eclass, baseType->getFullName().c_str());
+
+        // index with the __ls_constructor
+        BC::expToNextReg(fs, &eclass);
+
+        ExpDesc fname;
+        BC::expString(cs, &fname, "__ls_constructor");
+
+        BC::expToNextReg(fs, &fname);
+        BC::expToVal(fs, &fname);
+        BC::indexed(fs, &eclass, &fname);
+
+        // call the LSMethod
+        generateCall(&eclass, &expression->arguments);
+    }
+    else
+    {
+        utString name = currentMethod->getName();
+
+        if (expression->method)
+        {
+            name = expression->method->string;
+        }
+
+        MemberInfo *mi = baseType->findMember(name.c_str());
+        //FIXME: warn
+        if (!mi)
+        {
+            return expression;
+        }
+
+        lmAssert(mi->isMethod(), "super call on non-method");
+
+        MethodInfo *methodInfo = (MethodInfo *)mi;
+
+        // load up declaring class
+        ExpDesc eclass;
+        BC::singleVar(cs, &eclass,
+                      methodInfo->getDeclaringType()->getFullName().c_str());
+
+        BC::expToNextReg(fs, &eclass);
+
+        ExpDesc fname;
+        BC::expString(cs, &fname, name.c_str());
+
+        BC::expToNextReg(fs, &fname);
+        BC::expToVal(fs, &fname);
+        BC::indexed(fs, &eclass, &fname);
+
+        // call the LSMethod
+        generateCall(&eclass, &expression->arguments);
+
+        expression->e = eclass;
+    }
+
+    return expression;
+}
+
+Expression *TypeCompilerBase::visit(ThisLiteral *literal)
+{
+    BC::singleVar(cs, &literal->e, "this");
+
+    return literal;
+}
+
+
+Expression *TypeCompilerBase::visit(NullLiteral *literal)
+{
+    BC::initExpDesc(&literal->e, VKNIL, 0);
+
+    return literal;
+}
+
+
+Expression *TypeCompilerBase::visit(BooleanLiteral *literal)
+{
+    if (literal->value)
+    {
+        BC::initExpDesc(&literal->e, VKTRUE, 0);
+    }
+    else
+    {
+        BC::initExpDesc(&literal->e, VKFALSE, 0);
+    }
+
+    return literal;
+}
+
+
+Expression *TypeCompilerBase::visit(NumberLiteral *literal)
+{
+    ExpDesc e;
+    BC::initExpDesc(&e, VKNUM, 0);
+
+    setnumV(&e.u.nval, literal->value);
+
+    literal->e = e;
+    
+    return literal;
+}
+
+Expression *TypeCompilerBase::visit(ArrayLiteral *literal)
+{
+    lmAssert(0, "ArrayLiteral");
+    return literal;
+}
+
+Expression *TypeCompilerBase::visit(ObjectLiteral *literal)
+{
+    lmAssert(0, "ObjectLiteral");
+    return literal;
+}
+
+
+Expression *TypeCompilerBase::visit(ObjectLiteralProperty *property)
+{
+    lmAssert(0, "ObjectLiteralProperty");
+    return property;
+}
+
+
+Expression *TypeCompilerBase::visit(PropertyLiteral *property)
+{
+    lmAssert(0, "PropertyLiteral");
+    return property;
+}
+
+
+Expression *TypeCompilerBase::visit(DictionaryLiteralPair *pair)
+{
+    return pair;
+}
+
+Expression *TypeCompilerBase::visit(DictionaryLiteral *literal)
+{
+    FuncState *fs = cs->fs;
+
+    for (UTsize i = 0; i < literal->pairs.size(); i++)
+    {
+        int restore = fs->freereg;
+
+        DictionaryLiteralPair *pair = literal->pairs[i];
+
+        // comes in from NewExpression visitor
+        ExpDesc ethis = literal->e;
+
+        BC::expToNextReg(fs, &ethis);
+
+        pair->key->visitExpression(this);
+
+        BC::expToNextReg(fs, &pair->key->e);
+        BC::expToVal(fs, &pair->key->e);
+        BC::indexed(fs, &ethis, &pair->key->e);
+        
+        pair->value->visitExpression(this);
+        BC::storeVar(fs, &ethis, &pair->value->e);
+        
+        fs->freereg = restore;
+    }
+    
+    return literal;
+}
+
+Expression *TypeCompilerBase::visit(VariableDeclaration *declaration)
+{
+    FuncState *fs = cs->fs;
+
+    // local variable declaration
+    lmAssert(!declaration->classDecl, "local variable declaration belongs to a class");
+
+    ExpDesc v;
+    BC::singleVar(cs, &v, declaration->identifier->string.c_str());
+
+    Type       *dt     = declaration->type;
+    MethodInfo *method = NULL;
+    method = (MethodInfo *)dt->findMember("__op_assignment");
+
+    //TODO: assignment overload in default args?
+    if (declaration->isParameter)
+    {
+        method = NULL;
+    }
+
+    if (method)
+    {
+        if (dt->isStruct())
+        {
+            generateVarDeclStruct(declaration);
+        }
+        else if (dt->isDelegate())
+        {
+            generateVarDeclDelegate(declaration);
+        }
+        else
+        {
+            lmAssert(0, "unexpected __op_assignment on non delegate or struct");
+        }
+        
+        return declaration;
+    }
+    
+    else
+    {
+        lmAssert(!dt->isDelegate() && !dt->isStruct(),
+                 "unexpected delegate/struct");
+        
+        fs->freereg = fs->nactvar; /* free registers */
+        declaration->identifier->visitExpression(this);
+        declaration->initializer->visitExpression(this);
+        BC::storeVar(fs, &declaration->identifier->e,
+                     &declaration->initializer->e);
+    }
+    
+    return declaration;
 }
 
 

--- a/loom/script/compiler/lsTypeCompilerBase.cpp
+++ b/loom/script/compiler/lsTypeCompilerBase.cpp
@@ -32,6 +32,15 @@ extern "C" {
 #include "lj_obj.h"
 #include "lj_bcdump.h"
 }
+
+#else 
+
+// Some shims to let us write code with LuaJIT conventions but work against classic.
+#define VKNIL VNIL
+#define VKTRUE VTRUE
+#define VKFALSE VFALSE
+#define setnumV(var, val) *(var) = val;
+
 #endif
 
 namespace LS  {

--- a/loom/script/compiler/lsTypeCompilerBase.h
+++ b/loom/script/compiler/lsTypeCompilerBase.h
@@ -81,6 +81,10 @@ protected:
     {
     }
 
+    // Bytecode output helper
+    static int luaByteCodewriter(lua_State *L, const void *p, size_t size,
+                                 void *u);
+
     virtual void _compile();
 
     virtual void initCodeState(CodeState *codeState, FuncState *funcState, const utString& source) = 0;
@@ -105,6 +109,60 @@ protected:
     Expression *visit(YieldExpression *expression);
     Expression *visit(VectorLiteral *vector);
     Expression *visit(IncrementExpression *expression);
+
+    // Visit an array of statements in order, calling visitStatement on each.
+    utArray<Statement *> *visitStatementArray(utArray<Statement *> *_statements);
+    virtual Statement *visitStatement(Statement *statement)=0;
+
+    // Helpers to visit an array of expressions.
+    utArray<Expression *> *visitExpressionArray(utArray<Expression *> *_expressions);
+    Expression *visitExpression(Expression *expression);
+
+    // Assorted common visit implementations. Most of these pass through or error
+    // as they are syntactic elements that aren't important for us.
+    CompilationUnit *visit(CompilationUnit *cunit);
+    Statement *visit(FunctionDeclaration *declaration);
+    Statement *visit(PropertyDeclaration *declaration);
+    Statement *visit(BlockStatement *statement);
+    Statement *visit(EmptyStatement *statement);
+    Statement *visit(ExpressionStatement *statement);
+    Statement *visit(LabelledStatement *statement);
+    Statement *visit(VariableStatement *statement);
+    Statement *visit(WithStatement *statement);
+    Statement *visit(ClassDeclaration *statement);
+    Statement *visit(InterfaceDeclaration *statement);
+    Statement *visit(PackageDeclaration *statement);
+    Statement *visit(ImportStatement *statement);
+    Expression *visit(MultipleAssignmentExpression *expression);
+    Expression *visit(DeleteExpression *expression);
+    Expression *visit(LogicalAndExpression *expression);
+    Expression *visit(LogicalOrExpression *expression);
+    Expression *visit(ArrayLiteral *literal);
+    Expression *visit(ObjectLiteral *literal);
+    Expression *visit(ObjectLiteralProperty *property);
+    Expression *visit(PropertyLiteral *property);
+    Expression *visit(DictionaryLiteralPair *pair);
+
+    // More substantial common visitors.
+    Expression *visit(VariableExpression *expression);
+    Expression *visit(SuperExpression *expression);
+    Expression *visit(VariableDeclaration *declaration);
+    Expression *visit(ThisLiteral *literal);
+    Expression *visit(NullLiteral *literal);
+    Expression *visit(BooleanLiteral *literal);
+    Expression *visit(NumberLiteral *literal);
+    Expression *visit(DictionaryLiteral *literal);
+    Expression *visit(CallExpression *literal);
+    Expression *visit(NewExpression *expression);
+    virtual Expression *visit(BinaryOperatorExpression *expression)=0;
+
+    // Common helpers
+    void createVarArg(ExpDesc *varg, utArray<Expression *> *arguments,
+                      int startIdx);
+    int expList(ExpDesc *e, utArray<Expression *> *expressions, MethodBase *methodBase);
+
+    // Visit a chunk of statements in order and emit bytecode for them.
+    virtual void chunk(utArray<Statement *> *statements)=0;
 
     // struct
     void setupVarDecl(ExpDesc *out, VariableDeclaration *declaration);

--- a/loom/script/native/core/system/lmBaseDelegate.cpp
+++ b/loom/script/native/core/system/lmBaseDelegate.cpp
@@ -136,6 +136,7 @@ static int registerSystemBaseDelegate(lua_State *L)
        .beginClass<BaseDelegate> ("BaseDelegate")
 
        .addStaticLuaFunction("BaseDelegate", &BaseDelegate::_BaseDelegate)
+       .addStaticLuaFunction("__ls_constructor", &BaseDelegate::_BaseDelegate)
        .addStaticLuaFunction("__op_assignment", &BaseDelegate::__op_assignment)
        .addStaticLuaFunction("call", &BaseDelegate::call)
        .addStaticLuaFunction("__op_plusassignment", &BaseDelegate::__op_plusassignment)
@@ -144,7 +145,7 @@ static int registerSystemBaseDelegate(lua_State *L)
 
        .endClass()
 
-       .endPackage();
+   .endPackage();
 
     return 0;
 }

--- a/loom/script/native/core/system/lmConsole.cpp
+++ b/loom/script/native/core/system/lmConsole.cpp
@@ -36,8 +36,9 @@ int Console::print(lua_State *L)
     lua_rawgeti(L, 1, LSINDEXVECTOR);
     int vidx = lua_gettop(L);
 
-    // the value to print (concating all objects passed)
-    utString toprint;
+    // the value to print (concatenating all objects passed)
+    char outputBuffer[2048];
+    outputBuffer[0] = 0;
 
     for (int i = 0; i < length; i++)
     {
@@ -65,22 +66,22 @@ int Console::print(lua_State *L)
         }
 
         // concat
-        toprint += s;
+        strncat(outputBuffer, s, 2047);
 
         // truncate to 2000 characters
-        if (strlen(toprint.c_str()) > 2000)
+        if (strlen(outputBuffer) > 2000)
         {
             break;
         }
 
         if (i != length - 1)
         {
-            toprint += " ";
+            strncat(outputBuffer, " ", 2047);
         }
     }
 
     // print to log
-    LSLog(LSLogError, "%s", toprint.c_str());
+    LSLog(LSLogError, "%s", outputBuffer);
 
     return 0;
 }

--- a/loom/script/native/core/system/lmObject.cpp
+++ b/loom/script/native/core/system/lmObject.cpp
@@ -260,6 +260,9 @@ public:
     static int _nativeDeleted(lua_State *L)
     {
         lua_rawgeti(L, 1, LSINDEXDELETEDMANAGED);
+        int r = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+        lua_pushboolean(L, r);
         return 1;
     }
 

--- a/loom/script/native/lsLuaBridge.h
+++ b/loom/script/native/lsLuaBridge.h
@@ -1595,7 +1595,7 @@ public:
 //============================================================================
 
 /**
- *  Interface to a class poiner retrievable from a userdata.
+ *  Interface to a class pointer retrievable from a userdata.
  */
 class Userdata
 {
@@ -4048,7 +4048,7 @@ public:
 
                 ArgList<Params> args(L);
 
-                //NativeTypeBase* nativeType = NativeInterface::getNativeType<CT>();
+                NativeTypeBase* nativeType = NativeInterface::getNativeType<CT>();
 
                 ReturnType instance = FuncTraits<Func>::call(fp, args);
 

--- a/loom/script/native/lsNativeInterface.cpp
+++ b/loom/script/native/lsNativeInterface.cpp
@@ -213,7 +213,7 @@ int NativeInterface::getManagedObectCount(const char *classPath,
         lua_pop(L, 1);
 
         lua_rawgeti(L, -1, LSINDEXDELETEDMANAGED);
-        bool isDeleted = lua_toboolean(L, -1);
+        bool isDeleted = lua_toboolean(L, -1) != 0 ? true : false;
         lua_pop(L, 1);
 
         if (t == type && !isDeleted)

--- a/loom/script/native/lsNativeInterface.cpp
+++ b/loom/script/native/lsNativeInterface.cpp
@@ -411,11 +411,10 @@ void *lualoom_getnativepointer(lua_State *L, int index, bool replaceIndex, const
     return pointer;
 }
 
-#if 0
-// Dump the managed table, filtering to only show two types.
+// Dump the global table of managed instances, filtering to only show two types.
 static void lualoom_dumpmanagedtable(lua_State *L, Type *filterA, Type *filterB)
 {
-    printf("----- managed table dump -----\n");
+    LSLog(LSLogError, "----- managed table dump -----\n");
 
     NativeTypeBase *ntbA = NativeInterface::getNativeType(filterA);
     NativeTypeBase *ntbB = NativeInterface::getNativeType(filterB);
@@ -428,7 +427,7 @@ static void lualoom_dumpmanagedtable(lua_State *L, Type *filterA, Type *filterB)
         if(ud->m_nativeType == ntbA || ud->m_nativeType == ntbB)
         {
             // uses 'key' (at index -2) and 'value' (at index -1)
-            printf("%x - %s *%x\n", ud, ud->m_nativeType->getCTypeName().c_str(), ud->getPointer());
+            LSLog(LSLogError, "%x - %s *%x\n", ud, ud->m_nativeType->getCTypeName().c_str(), ud->getPointer());
         }
 
         // removes 'value'; keeps 'key' for next iteration
@@ -436,7 +435,6 @@ static void lualoom_dumpmanagedtable(lua_State *L, Type *filterA, Type *filterB)
     }
     lua_pop(L, 1);
 }
-#endif
 
 void lualoom_downcastnativeinstance(lua_State *L, int instanceIdx, Type *fromType, Type *toType)
 {
@@ -446,6 +444,10 @@ void lualoom_downcastnativeinstance(lua_State *L, int instanceIdx, Type *fromTyp
     lmAssert(toType->isDerivedFrom(fromType), "lualoom_downcastnativeinstance - downcasting unrelated type %s to type %s", fromType->getFullName().c_str(), toType->getFullName().c_str());
     lmAssert(!toType->isInterface() && !fromType->isInterface(), "lualoom_downcastnativeinstance - downcasting interface type in cast type %s to type %s", fromType->getFullName().c_str(), toType->getFullName().c_str());
 
+    // This and the one at the end of the function are useful when debugging
+    // downcast issues - you can see if erroneous instances are present in the
+    // table and if the table was modified properly. It filters to only show
+    // instances matching the types we are casting from and to.
     //lualoom_dumpmanagedtable(L, fromType, toType);
 
     int top = lua_gettop(L);

--- a/loom/script/native/lsNativeInterface.h
+++ b/loom/script/native/lsNativeInterface.h
@@ -256,7 +256,8 @@ public:
     }
 };
 
-// Managed native classes can be inherited and extended via LoomScript.  They can also use custom allocation/pooling systems.
+// Managed native classes can be inherited and extended via LoomScript.  They
+// can also use custom allocation/pooling systems.
 
 template<class T>
 class ManagedNativeType : public NativeType<T> {
@@ -654,24 +655,16 @@ public:
         if (toType->isDerivedFrom(fromType))
         {
             NativeTypeBase *to = getNativeType(toType);
-
             if (to->functionCast(ptr))
             {
-                if (toType->isDerivedFrom(fromType))
-                {
-                    lualoom_downcastnativeinstance(L, instanceIdx, fromType, toType);
-                    lua_pushvalue(L, instanceIdx);
-                    return true;
-                }
-
-                // this is a valid cast, we must push a new native for unmanaged
-                // in the case of unmanaged to account for new class table
-                // managed native will reuse from the managed table
-                lualoom_pushnative(L, to, ptr);
+                // Handle the downcast - we may have to initialize fields.
+                lualoom_downcastnativeinstance(L, instanceIdx, fromType, toType);
+                lua_pushvalue(L, instanceIdx);
                 return true;
             }
         }
 
+        // Cast failed, return NULL.
         lua_pushnil(L);
         return false;
     }

--- a/loom/script/reflection/lsMethodInfo.cpp
+++ b/loom/script/reflection/lsMethodInfo.cpp
@@ -25,11 +25,6 @@
 namespace LS {
 Object *MethodBase::invoke(void *othis, int numParams)
 {
-    if (!attr.isNative)
-    {
-        assert(byteCode);
-    }
-
     LSLuaState *ls = getModule()->getAssembly()->getLuaState();
     lua_State  *L  = ls->VM();
 

--- a/loom/script/reflection/lsType.cpp
+++ b/loom/script/reflection/lsType.cpp
@@ -319,11 +319,12 @@ ConstructorInfo *Type::getConstructor()
     for (UTsize i = 0; i < members.size(); i++)
     {
         MemberInfo *m = members.at(i);
-        if (m->isConstructor())
-        {
-            cachedConstructor = (ConstructorInfo *)m;
-            return (ConstructorInfo *)m;
-        }
+        if (!m->isConstructor())
+            continue;
+
+        // Store match to return faster next time.
+        cachedConstructor = (ConstructorInfo *)m;
+        return (ConstructorInfo *)m;
     }
 
     return NULL;

--- a/loom/script/reflection/lsType.cpp
+++ b/loom/script/reflection/lsType.cpp
@@ -313,11 +313,15 @@ MethodInfo *Type::findOperatorMethod(const utString& methodName)
 
 ConstructorInfo *Type::getConstructor()
 {
+    if(cachedConstructor)
+        return cachedConstructor;
+
     for (UTsize i = 0; i < members.size(); i++)
     {
         MemberInfo *m = members.at(i);
         if (m->isConstructor())
         {
+            cachedConstructor = (ConstructorInfo *)m;
             return (ConstructorInfo *)m;
         }
     }

--- a/loom/script/reflection/lsType.h
+++ b/loom/script/reflection/lsType.h
@@ -132,6 +132,9 @@ private:
     // allocated as an array of pointers for fastest memory access
     MemberInfo **memberInfoOrdinalLookup;
 
+    bool hadInstanceInitializer;
+    bool hadStaticInstanceInitializer;
+
 public:
 
     Type() :
@@ -140,7 +143,8 @@ public:
         bcStaticInitializer(NULL), bcInstanceInitializer(NULL),
         fieldInfoCount(-1), methodInfoCount(-1), propertyInfoCount(-1),
         fieldMembersValid(false), methodMembersValid(false), propertyMembersValid(false),
-        cached(false), maxMemberOrdinal(0), memberInfoOrdinalLookup(NULL)
+        cached(false), maxMemberOrdinal(0), memberInfoOrdinalLookup(NULL),
+        hadInstanceInitializer(false), hadStaticInstanceInitializer(false)
     {
     }
 
@@ -628,6 +632,8 @@ public:
     {
         if (bcStaticInitializer != NULL) lmDelete(NULL, bcStaticInitializer);
         bcStaticInitializer = bc;
+        if(bc->getByteCode().size() != 0)
+            hadStaticInstanceInitializer = true;
     }
 
     ByteCode *getBCStaticInitializer()
@@ -639,11 +645,23 @@ public:
     {
         if (bcInstanceInitializer != NULL) lmDelete(NULL, bcInstanceInitializer);
         bcInstanceInitializer = bc;
+        if(bc->getByteCode().size() != 0)
+            hadInstanceInitializer = true;
     }
 
     ByteCode *getBCInstanceInitializer()
     {
         return bcInstanceInitializer;
+    }
+
+    bool hasInstanceInitializer() const
+    {
+        return hadInstanceInitializer;
+    }
+
+    bool hasStaticInstanceInitializer() const
+    {
+        return hadStaticInstanceInitializer;
     }
 
     Type *castToType(Type *to, bool tryReverse = false);

--- a/loom/script/reflection/lsType.h
+++ b/loom/script/reflection/lsType.h
@@ -332,11 +332,14 @@ public:
             return true;
         }
 
+        // Check parents.
         Type *base = baseType;
         while (base)
         {
             if (base->attr.isNativeManaged)
             {
+                // Propagate flag to this item to save on subsequent iteration.
+                attr.isNativeManaged = true;
                 return true;
             }
             base = base->baseType;

--- a/loom/script/runtime/lsClassRT.cpp
+++ b/loom/script/runtime/lsClassRT.cpp
@@ -74,7 +74,7 @@ void lualoom_callscriptinstanceinitializerchain_internal(lua_State *L, Type *typ
         // this is not the constructor, which is a method
         lua_getfield(L, -1, "__ls_instanceinitializer");
 
-        printf("Running initializer for %s\n", t->getFullName().c_str());
+        //printf("Running initializer for %s\n", t->getFullName().c_str());
 
         // call initializer on new instance.
         lua_pushvalue(L, instanceIdx);
@@ -249,7 +249,7 @@ static int lsr_classcreateinstance(lua_State *L)
     Type *nt = type->getNativeBaseType();
     if(nt)
     {
-        LSLog(LSLogError, "Creating native: %s", nt->getFullName().c_str());
+        //LSLogDebug(LSLogError, "Creating native: %s", nt->getFullName().c_str());
 
         int ntop = lua_gettop(L);
         lua_getglobal(L, "__ls_nativeclasses");

--- a/loom/script/runtime/lsClassRT.cpp
+++ b/loom/script/runtime/lsClassRT.cpp
@@ -126,6 +126,8 @@ void lualoom_newscriptinstance_internal(lua_State *L, Type *type)
     lua_setmetatable(L, instanceIdx);
 }
 
+#if 0
+    // useful debug stuff to be cleaned up
     void PrintTable(lua_State *L);
 
 
@@ -205,6 +207,7 @@ void lualoom_newscriptinstance_internal(lua_State *L, Type *type)
 
         printf("}\n");
     }
+#endif
 
 // class instance creator
 static int lsr_classcreateinstance(lua_State *L)
@@ -1063,7 +1066,7 @@ void lsr_classinitializestatic(lua_State *L, Type *type)
     // run the static initializer
     lua_getfield(L, clsIdx, "__ls_staticinitializer");
 
-    printf("running static initializer %s\n", type->getFullName().c_str());
+    //printf("running static initializer %s\n", type->getFullName().c_str());
 
     if (lua_pcall(L, 0, LUA_MULTRET, 0))
     {

--- a/loom/script/runtime/lsInstanceRT.cpp
+++ b/loom/script/runtime/lsInstanceRT.cpp
@@ -404,7 +404,7 @@ static int lsr_instanceindex(lua_State *L)
     else
     {
         mi = type->findMember(name, true);
-        lmAssert(mi, "Unable to find member via string %s : %s", type->getFullName().c_str(), name);
+        lmAssert(mi, "Unable to find member '%s' via string on instance of type %s", name, type->getFullName().c_str());
         assert(mi);
         assert(mi->isMethod());
         assert(mi->getOrdinal());

--- a/sdk/src/loom2d/Display/DisplayObjectContainer.ls
+++ b/sdk/src/loom2d/Display/DisplayObjectContainer.ls
@@ -58,10 +58,6 @@ package loom2d.display
         public native function set depthSort(value:Boolean);
         public native function get depthSort():Boolean;
 
-        /** View controls which indexed view the container's children will be drawn into */
-        //public native function set view(value:int);
-        //public native function get view():int;
-
         /**
          * Native implementation for clip rect functionality; this passes the 
          * clip rect to the native rendering code. Render of this container's

--- a/sdk/src/test/tests/TestManagedNativeClass.ls
+++ b/sdk/src/test/tests/TestManagedNativeClass.ls
@@ -98,25 +98,22 @@ class TestManagedNativeClass
     [Test]
     function testSharedInstance()
     {
-        trace("A");
         var instance = new MyChildManagedNativeClass();
         Assert.equal(instance.scriptString, "Hello, ", "Failed to initalize simple class instance member.");
 
-        trace("B");
         var child = new MyChildManagedNativeClass();
         Assert.equal(child.scriptString, "Hello, ", "Failed to initalize subclass instance members.");
         Assert.equal((child as MyChildManagedNativeClass).scriptStringChild, "World!", "Failed to initalize downcasted instance members.");
 
         instance.child = child;
         child = null;
-        trace("C");
+
         GC.fullCollect();
-        trace("D");
+
         child = instance.getChild() as MyChildManagedNativeClass;
 
         Assert.equal(child.scriptString, "Hello, ");
         Assert.equal((child as MyChildManagedNativeClass).scriptStringChild, "World!");
-        trace("E");
 
         instance.deleteNative();
         child.deleteNative();
@@ -129,7 +126,6 @@ class TestManagedNativeClass
         Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
         Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
 
-        trace("A");
         var testdowncast = MyChildManagedNativeClass.createMyChildManagedNativeClassAsMyManagedNativeClass();
         Assert.equal(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
         Assert.equal(testdowncast.getType().getName(), "MyManagedNativeClass");
@@ -138,17 +134,13 @@ class TestManagedNativeClass
         // set the script var, when we downcast below, the object initializer should
         // only be called for up to and not including the current type (if it was called it would 
         // reset this to "Hello!!!"
-        trace("B");
         testdowncast.scriptString = "Happy New Year!!!";
         
         // native side has a MyChildManagedNativeClass instance, but we don't know about it 
         // as we have't downcasted yet
         Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);        
-        
-        trace("C");
-        var downcast = testdowncast as MyChildManagedNativeClass;
 
-        trace("D");
+        var downcast = testdowncast as MyChildManagedNativeClass;
 
         // once we downcast, the managed system is updated with new RTTI
         Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);        

--- a/sdk/src/test/tests/TestManagedNativeClass.ls
+++ b/sdk/src/test/tests/TestManagedNativeClass.ls
@@ -96,6 +96,29 @@ class TestManagedNativeClass
     }
 
     [Test]
+    function testSharedInstance()
+    {
+        trace("A");
+        var instance = new MyChildManagedNativeClass();
+        Assert.equal(instance.scriptString, "Hello, ", "Failed to initalize simple class instance member.");
+
+        trace("B");
+        var child = new MyChildManagedNativeClass();
+        Assert.equal(child.scriptString, "Hello, ", "Failed to initalize subclass instance members.");
+        Assert.equal((child as MyChildManagedNativeClass).scriptStringChild, "World!", "Failed to initalize downcasted instance members.");
+
+        instance.child = child;
+        child = null;
+        trace("C");
+        GC.fullCollect();
+        trace("D");
+        child = instance.getChild() as MyChildManagedNativeClass;
+
+        Assert.equal(child.scriptString, "Hello, ");
+        Assert.equal((child as MyChildManagedNativeClass).scriptStringChild, "World!");
+        trace("E");
+    }
+
     function test()
     {        
         var instance = new MyManagedNativeClass();
@@ -121,12 +144,11 @@ class TestManagedNativeClass
         
         // note this is a native field, GC isn't holding child
         instance.child = child;
-        
         child = null;
         
         // call GC, though as MyChildManagedNativeClass has a managed class in it's inheritance graph
         // system will still hold onto it
-        GC.collect();
+        GC.fullCollect();
         
         retrieveChild(instance);
         

--- a/sdk/src/test/tests/TestManagedNativeClass.ls
+++ b/sdk/src/test/tests/TestManagedNativeClass.ls
@@ -85,29 +85,33 @@ final native class MyChildManagedNativeClass extends MyManagedNativeClass {
     }
 }
 
-class TestManagedNativeClass
+/**
+ * Tests of the managed native system - that is, objects that are
+ * mixed script and native code and data.
+ */
+class ManagedNativeClassTest
 {
-    function retrieveChild(owner:MyManagedNativeClass) {
-        
+    function retrieveChild(owner:MyManagedNativeClass) 
+    {
         // get the child, and make sure the script value is still valid magic! 
         var child = owner.getChild();
-        Assert.equal(child.scriptString, "Hello, ");
-        Assert.equal((child as MyChildManagedNativeClass).scriptStringChild, "World!");
+        Assert.compare(child.scriptString, "Hello, ");
+        Assert.compare((child as MyChildManagedNativeClass).scriptStringChild, "World!");
     }
 
     [Test]
     function testSharedInstance()
     {
         // We should be in a clean state.
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
 
         var instance = new MyChildManagedNativeClass();
-        Assert.equal(instance.scriptString, "Hello, ", "Failed to initalize simple class instance member.");
+        Assert.compare(instance.scriptString, "Hello, ", "Failed to initalize simple class instance member.");
 
         var child = new MyChildManagedNativeClass();
-        Assert.equal(child.scriptString, "Hello, ", "Failed to initalize subclass instance members.");
-        Assert.equal((child as MyChildManagedNativeClass).scriptStringChild, "World!", "Failed to initalize downcasted instance members.");
+        Assert.compare(child.scriptString, "Hello, ", "Failed to initalize subclass instance members.");
+        Assert.compare((child as MyChildManagedNativeClass).scriptStringChild, "World!", "Failed to initalize downcasted instance members.");
 
         instance.child = child;
         child = null;
@@ -116,15 +120,15 @@ class TestManagedNativeClass
 
         child = instance.getChild() as MyChildManagedNativeClass;
 
-        Assert.equal(child.scriptString, "Hello, ");
-        Assert.equal((child as MyChildManagedNativeClass).scriptStringChild, "World!");
+        Assert.compare(child.scriptString, "Hello, ");
+        Assert.compare((child as MyChildManagedNativeClass).scriptStringChild, "World!");
 
         instance.deleteNative();
         child.deleteNative();
 
         // We should be in a clean state.
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
 
     }
 
@@ -132,13 +136,13 @@ class TestManagedNativeClass
     function testDowncast()
     {
         // We should be in a clean state.
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
 
         var testdowncast = MyChildManagedNativeClass.createMyChildManagedNativeClassAsMyManagedNativeClass();
-        Assert.equal(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
-        Assert.equal(testdowncast.getType().getName(), "MyManagedNativeClass");
-        Assert.equal(testdowncast.scriptString, "Hello, ");
+        Assert.compare(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
+        Assert.compare(testdowncast.getType().getName(), "MyManagedNativeClass");
+        Assert.compare(testdowncast.scriptString, "Hello, ");
         
         // set the script var, when we downcast below, the object initializer should
         // only be called for up to and not including the current type (if it was called it would 
@@ -147,30 +151,30 @@ class TestManagedNativeClass
         
         // native side has a MyChildManagedNativeClass instance, but we don't know about it 
         // as we have't downcasted yet
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);        
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);        
 
         var downcast = testdowncast as MyChildManagedNativeClass;
 
         // once we downcast, the managed system is updated with new RTTI
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);        
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);        
         
-        Assert.equal(downcast, testdowncast);
-        Assert.equal(downcast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
-        Assert.equal(downcast.getType().getName(), "MyChildManagedNativeClass");
-        Assert.equal(downcast.scriptString, "Happy New Year!!!");
-        Assert.equal(downcast.scriptStringChild, "World!");
+        Assert.compare(downcast, testdowncast);
+        Assert.compare(downcast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
+        Assert.compare(downcast.getType().getName(), "MyChildManagedNativeClass");
+        Assert.compare(downcast.scriptString, "Happy New Year!!!");
+        Assert.compare(downcast.scriptStringChild, "World!");
 
         // now that we have downcast, testdowncase will automatically be promoted to better RTTI
-        Assert.equal(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
-        Assert.equal(testdowncast.getType().getName(), "MyChildManagedNativeClass");
-        Assert.equal(testdowncast.scriptString, "Happy New Year!!!");
+        Assert.compare(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
+        Assert.compare(testdowncast.getType().getName(), "MyChildManagedNativeClass");
+        Assert.compare(testdowncast.scriptString, "Happy New Year!!!");
         
         // We can delete on the original reference
         testdowncast.deleteNative();
         
         // and the backend takes care of all the messy stuff
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
     }
 
     [Test]
@@ -178,10 +182,10 @@ class TestManagedNativeClass
     {        
         var instance = new MyManagedNativeClass();
 
-        Assert.equal(instance.intProperty, 101);
+        Assert.compare(instance.intProperty, 101);
         Assert.isFalse(instance.nativeDeleted());        
-        Assert.equal(instance.getDescString(100), "100 0 0.00 0.00");                
-        Assert.equal(instance.getDescStringBool(true), "true 0 0.00 0.00");
+        Assert.compare(instance.getDescString(100), "100 0 0.00 0.00");                
+        Assert.compare(instance.getDescStringBool(true), "true 0 0.00 0.00");
         
         var child = new MyChildManagedNativeClass();
 
@@ -189,13 +193,13 @@ class TestManagedNativeClass
         //https://theengineco.atlassian.net/browse/LOOM-1427    
         //assert(child.intProperty == 102);
         
-        Assert.equal(child.getDescStringChildOverride("hello"), "hello 1 1.00 1.00 default string");
+        Assert.compare(child.getDescStringChildOverride("hello"), "hello 1 1.00 1.00 default string");
         
         child.intField = 3000;
         child.doubleField = 10000;
         child.stringField = "goodbye";
         
-        Assert.equal(child.getDescStringBool(false), "false 3000 1.00 10000.00 goodbye");
+        Assert.compare(child.getDescStringBool(false), "false 3000 1.00 10000.00 goodbye");
         
         // note this is a native field, GC isn't holding child
         instance.child = child;
@@ -207,8 +211,8 @@ class TestManagedNativeClass
         
         retrieveChild(instance);
         
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 1);
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 1);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);
 
         instance.child.deleteNative();
         instance.deleteNative();
@@ -222,20 +226,20 @@ class TestManagedNativeClass
         // Console.print(instance.getDescString);
         
         
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
         
         var instances:Vector.<MyManagedNativeClass>  = new Vector.<MyManagedNativeClass>;
         var i:int;
         for (i = 0; i < 1000; i++) 
             instances.push(new MyManagedNativeClass);
         
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 1000);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 1000);
         
         while(instances.length)
             instances.shift().deleteNative();
             
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
 
         // create 1k managed natives with a mix of script and native instantiated        
         var iv:Vector.<MyManagedNativeClass> = new Vector.<MyManagedNativeClass>();
@@ -248,47 +252,47 @@ class TestManagedNativeClass
         for (i = 0; i < MyManagedNativeClass.getNumInstances(); i++) {
             
             instance = MyManagedNativeClass.getInstance(i);
-            Assert.equal(iv[i].getNativeDebugString(), instance.getNativeDebugString(), "mismatch between script help and native returned managed");
+            Assert.compare(iv[i].getNativeDebugString(), instance.getNativeDebugString(), "mismatch between script help and native returned managed");
             
         }
         
         var testi = new MyManagedNativeClass();
         testi.stringField = "This is a test";
-        Assert.equal(testi.stringField, "This is a test");
+        Assert.compare(testi.stringField, "This is a test");
         testi.deleteNative();
                 
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 1024, "mismatch on MyManagedNativeClass count");
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 1024, "mismatch on MyManagedNativeClass count");
         
         // go through and delete random instances from C++ side (note some of these instances were created in script and some in C++
         for (i = 0; i < 512; i++) {
             MyManagedNativeClass.deleteRandomInstance();
         }
         
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 512, "mismatch on MyManagedNativeClass count post delete");
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 512, "mismatch on MyManagedNativeClass count post delete");
         
         // delete the rest
         for (i = 0; i < 512; i++) {
             MyManagedNativeClass.deleteRandomInstance();
         }
         
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0, "lingering MyManagedNativeClass count post delete all");        
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0, "lingering MyManagedNativeClass count post delete all");        
         
         
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
         var nativeSide = MyChildManagedNativeClass.createMyChildManagedNativeClassNativeSide();
-        Assert.equal(nativeSide.stringField, "created native side");        
+        Assert.compare(nativeSide.stringField, "created native side");        
         
         // REPRO CASE FOR LOOM
-        Assert.equal(nativeSide.scriptString, "Hello, ");
+        Assert.compare(nativeSide.scriptString, "Hello, ");
         
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);
         
         nativeSide.deleteNative();
                 
         var testdowncast = MyChildManagedNativeClass.createMyChildManagedNativeClassAsMyManagedNativeClass();
-        Assert.equal(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
-        Assert.equal(testdowncast.getType().getName(), "MyManagedNativeClass");
-        Assert.equal(testdowncast.scriptString, "Hello, ");
+        Assert.compare(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
+        Assert.compare(testdowncast.getType().getName(), "MyManagedNativeClass");
+        Assert.compare(testdowncast.scriptString, "Hello, ");
         
         // set the script var, when we downcast below, the object initializer should
         // only be called for up to and not including the current type (if it was called it would 
@@ -297,30 +301,30 @@ class TestManagedNativeClass
         
         // native side has a MyChildManagedNativeClass instance, but we don't know about it 
         // as we have't downcasted yet
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);        
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);        
         
         var downcast = testdowncast as MyChildManagedNativeClass;
 
         // once we downcast, the managed system is updated with new RTTI
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);        
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 1);        
         
-        Assert.equal(downcast, testdowncast);
-        Assert.equal(downcast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
-        Assert.equal(downcast.getType().getName(), "MyChildManagedNativeClass");
-        Assert.equal(downcast.scriptString, "Happy New Year!!!");
-        Assert.equal(downcast.scriptStringChild, "World!");
+        Assert.compare(downcast, testdowncast);
+        Assert.compare(downcast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
+        Assert.compare(downcast.getType().getName(), "MyChildManagedNativeClass");
+        Assert.compare(downcast.scriptString, "Happy New Year!!!");
+        Assert.compare(downcast.scriptStringChild, "World!");
 
         // now that we have downcast, testdowncase will automatically be promoted to better RTTI
-        Assert.equal(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
-        Assert.equal(testdowncast.getType().getName(), "MyChildManagedNativeClass");
-        Assert.equal(testdowncast.scriptString, "Happy New Year!!!");
+        Assert.compare(testdowncast.stringField, "created by createMyChildManagedNativeClassAsMyManagedNativeClass");
+        Assert.compare(testdowncast.getType().getName(), "MyChildManagedNativeClass");
+        Assert.compare(testdowncast.scriptString, "Happy New Year!!!");
         
         // We can delete on the original reference
         testdowncast.deleteNative();
         
         // and the backend takes care of all the messy stuff
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
-        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.compare(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
         
         // make sure we handle deleting this in callstack
         var testDelete = new MyManagedNativeClass;

--- a/sdk/src/test/tests/TestManagedNativeClass.ls
+++ b/sdk/src/test/tests/TestManagedNativeClass.ls
@@ -98,6 +98,10 @@ class TestManagedNativeClass
     [Test]
     function testSharedInstance()
     {
+        // We should be in a clean state.
+        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+
         var instance = new MyChildManagedNativeClass();
         Assert.equal(instance.scriptString, "Hello, ", "Failed to initalize simple class instance member.");
 
@@ -117,6 +121,11 @@ class TestManagedNativeClass
 
         instance.deleteNative();
         child.deleteNative();
+
+        // We should be in a clean state.
+        Assert.equal(Metrics.getManagedObjectCount("tests.MyManagedNativeClass"), 0);
+        Assert.equal(Metrics.getManagedObjectCount("tests.MyChildManagedNativeClass"), 0);
+
     }
 
     [Test]


### PR DESCRIPTION
Added allocation benchmark. 10k allocations went from 335ms to 200ms avg time on 2.6ghz MacBook Pro (Retina, 13-inch, Mid 2014).
Constructors now call their own supers.
Instance initializer blocks are also now part of constructor, but are also kept separately for use when wrapping natives.
Tweaked script instance memory allocation to achieve better performance (on OSX).
Type now caches many frequently called queries to avoid massive data structure traversals during object construction.
Console::Log now avoids memory allocation.
Tested with JIT and Classic Lua.