### PR TITLE
Made getBounds return a Rectangle allocated on heap

### DIFF
--- a/loom/engine/loom2d/l2dScript.cpp
+++ b/loom/engine/loom2d/l2dScript.cpp
@@ -67,16 +67,16 @@ bool Loom2DNative::sInitialized = false;
 
 static Matrix *StaticMatrixConstructor(lua_State *L)
 {
-    return lmNew(NULL) Matrix((float)lua_tonumber(L, 2), (float)lua_tonumber(L, 3),
-                      (float)lua_tonumber(L, 4), (float)lua_tonumber(L, 5),
-                      (float)lua_tonumber(L, 6), (float)lua_tonumber(L, 7));
+    return lmNew(NULL) Matrix((lmscalar)lua_tonumber(L, 2), (lmscalar)lua_tonumber(L, 3),
+                      (lmscalar)lua_tonumber(L, 4), (lmscalar)lua_tonumber(L, 5),
+                      (lmscalar)lua_tonumber(L, 6), (lmscalar)lua_tonumber(L, 7));
 }
 
 
 static Rectangle *StaticRectangleConstructor(lua_State *L)
 {
-    return lmNew(NULL) Rectangle((float)lua_tonumber(L, 2), (float)lua_tonumber(L, 3),
-                         (float)lua_tonumber(L, 4), (float)lua_tonumber(L, 5));
+    return lmNew(NULL) Rectangle((lmscalar)lua_tonumber(L, 2), (lmscalar)lua_tonumber(L, 3),
+                         (lmscalar)lua_tonumber(L, 4), (lmscalar)lua_tonumber(L, 5));
 }
 
 

--- a/loom/graphics/gfxVectorGraphics.cpp
+++ b/loom/graphics/gfxVectorGraphics.cpp
@@ -550,11 +550,9 @@ void VectorGraphics::resetStyle() {
 }
 
 #pragma warning(disable: 4056 4756)
-Loom2D::Rectangle VectorGraphics::getBounds() {
-	//float* bounds = VectorRenderer::getBounds();
-	//return Loom2D::Rectangle(bounds[0], bounds[1], bounds[2], bounds[3]);
-	if (boundL == INFINITY || boundT == INFINITY || boundR == -INFINITY || boundB == -INFINITY) return Loom2D::Rectangle(0.f, 0.f, 0.f, 0.f);
-	return Loom2D::Rectangle(boundL, boundT, boundR-boundL, boundB-boundT);
+Loom2D::Rectangle* VectorGraphics::getBounds() {
+	if (boundL == INFINITY || boundT == INFINITY || boundR == -INFINITY || boundB == -INFINITY) return lmNew(NULL) Loom2D::Rectangle(0.f, 0.f, 0.f, 0.f);
+	return lmNew(NULL) Loom2D::Rectangle(boundL, boundT, boundR-boundL, boundB-boundT);
 #pragma warning(default: 4056 4756)
 }
 

--- a/loom/graphics/gfxVectorGraphics.h
+++ b/loom/graphics/gfxVectorGraphics.h
@@ -232,7 +232,7 @@ public:
 	void beginTextureFill(TextureID id, Loom2D::Matrix *matrix, bool repeat, bool smooth);
 	void endFill();
 
-	Loom2D::Rectangle getBounds();
+	Loom2D::Rectangle* getBounds();
 
 	void moveTo(float x, float y);
 	void lineTo(float x, float y);


### PR DESCRIPTION
... which fixes an alignment crash on Android