### PR TITLE
Do we want glFInish?

### DIFF
--- a/loom/engine/loom2d/l2dStage.cpp
+++ b/loom/engine/loom2d/l2dStage.cpp
@@ -135,9 +135,11 @@ void Stage::render(lua_State *L)
     if (vm) lualoom_gc_update(vm->VM());
     LOOM_PROFILE_END(garbageCollection);
 
+#ifdef LOOM_DEBUG
     LOOM_PROFILE_START(finishRender);
     GFX::Graphics::context()->glFinish();
     LOOM_PROFILE_END(finishRender);
+#endif
 
     LOOM_PROFILE_START(waitForVSync);
     /* Update the screen! */

--- a/loom/engine/loom2d/l2dStage.cpp
+++ b/loom/engine/loom2d/l2dStage.cpp
@@ -134,7 +134,11 @@ void Stage::render(lua_State *L)
     LOOM_PROFILE_START(garbageCollection);
     if (vm) lualoom_gc_update(vm->VM());
     LOOM_PROFILE_END(garbageCollection);
-    
+
+    LOOM_PROFILE_START(finishRender);
+    GFX::Graphics::context()->glFinish();
+    LOOM_PROFILE_END(finishRender);
+
     LOOM_PROFILE_START(waitForVSync);
     /* Update the screen! */
     SDL_GL_SwapWindow(sdlWindow);


### PR DESCRIPTION
 Maybe it's useful for some cases so gl doesn't randomly decide when to process commands, though this call might be ignored by some drivers?