### PR TITLE
getGameController no longer returns `null`

### DIFF
--- a/loom/engine/bindings/loom/lmGameController.cpp
+++ b/loom/engine/bindings/loom/lmGameController.cpp
@@ -133,7 +133,7 @@ LoomGameController *LoomGameController::getGameController(int index = -1)
             if (LoomGameController::controllers[i].is_connected)
                 return &controllers[i];
     }
-    else if (index < MAX_CONTROLLERS)
+    else
     {
         return &controllers[index];
     }

--- a/loom/engine/bindings/loom/lmGameController.cpp
+++ b/loom/engine/bindings/loom/lmGameController.cpp
@@ -122,9 +122,11 @@ int LoomGameController::getControllerIndex(SDL_JoystickID instance)
 }
 
 /** Returns the pointer to a game controller on a specific index in the 'controllers' pool.
- * If index is negative it returns the first connected game controller in pool. */
+ * If index is negative it returns the first connected game controller in pool, 
+ * if there are no controllers connected it returns the first controller in pool. */
 LoomGameController *LoomGameController::getGameController(int index = -1)
 {
+    lmAssert(index < MAX_CONTROLLERS, "Controller index out of range.");
     if (index < 0)
     {
         for (int i = 0; i < MAX_CONTROLLERS; i++)
@@ -133,10 +135,9 @@ LoomGameController *LoomGameController::getGameController(int index = -1)
     }
     else if (index < MAX_CONTROLLERS)
     {
-        if (LoomGameController::controllers[index].is_connected)
-            return &controllers[index];
+        return &controllers[index];
     }
-    return nullptr;
+    return &controllers[0];
 }
 
 /** Returns true if device has rumble support. */


### PR DESCRIPTION
getGameController method no longer returns `null` if trying to access a controller that is not connected. An assert was added to make sure controller index is not too high.