### PR TITLE
Docs path fix

### DIFF
--- a/build/Swarley
+++ b/build/Swarley
@@ -47,7 +47,7 @@ namespace :package do
     FileUtils.cp("MIN_CLI_VERSION", "pkg/sdk")
 
     # docs
-    cp_r_safe("artifacts/docs/docs", "pkg/sdk")
+    cp_r_safe("artifacts/docs", "pkg/sdk")
 
     # ios
     cp_r_safe("artifacts/ios-arm/fruitstrap", "pkg/sdk/bin/ios-arm/tools")


### PR DESCRIPTION
This along with the build box fix should make docs work, tested with `loom docs`, can't test `loom new` without firehose or implementing custom sdks.