### PR TITLE
Fixed map caching along with some related functionality and added File.move

### DIFF
--- a/loom/common/assets/assets.cpp
+++ b/loom/common/assets/assets.cpp
@@ -223,7 +223,12 @@ static int loom_asset_isOnTrackToLoad(loom_asset_t *asset)
 
 static loom_asset_t *loom_asset_getAssetByName(const char *name, int create)
 {
-    utHashedString key        = platform_normalizePath(name);
+    loom_mutex_lock(gAssetLock);
+    static char normalized[4096];
+    strncpy(normalized, name, sizeof(normalized));
+    platform_normalizePath(normalized);
+    utHashedString key        = normalized;
+    loom_mutex_unlock(gAssetLock);
     loom_asset_t   **assetPtr = gAssetHash.get(key);
     loom_asset_t   *asset     = assetPtr ? *assetPtr : NULL;
 

--- a/loom/common/platform/platformFile.c
+++ b/loom/common/platform/platformFile.c
@@ -27,33 +27,23 @@
 
 const char *platform_getFolderDelimiter();
 
-const char *platform_normalizePath(const char *path)
+void platform_normalizePath(char *path)
 {
-    static char npath[4096];
     size_t      i;
     size_t      nlen;
     char        delimiter;
 
     nlen = strlen(path);
 
-    if (nlen > 4000)
-    {
-        return "";
-    }
-
-    strcpy(npath, path);
-
     delimiter = platform_getFolderDelimiter()[0];
 
     for (i = 0; i < nlen; i++)
     {
-        if ((npath[i] == '\\') || (npath[i] == '/'))
+        if ((path[i] == '\\') || (path[i] == '/'))
         {
-            npath[i] = delimiter;
+            path[i] = delimiter;
         }
     }
-
-    return npath;
 }
 
 
@@ -97,6 +87,11 @@ int platform_removeFile(const char *path)
     fclose(file);
 
     return remove(path);
+}
+
+int platform_moveFile(const char *source, const char *dest)
+{
+    return rename(source, dest);
 }
 
 

--- a/loom/common/platform/platformFile.h
+++ b/loom/common/platform/platformFile.h
@@ -113,7 +113,7 @@ int platform_removeDir(const char *path);
  *
  * @param path Path to normalize.
  */
-void platform_normalizePath(const char *path);
+void platform_normalizePath(char *path);
 
 /*!
  * Returns / or \ depending on platform.

--- a/loom/common/platform/platformFile.h
+++ b/loom/common/platform/platformFile.h
@@ -56,7 +56,7 @@ void platform_getCurrentExecutablePath(char *out, unsigned int maxLen);
 const char *platform_getWritablePath();
 
 /*!
- * What is the current working directory?
+ * Recursively create the folders in path
  *
  * @param path recursively creates the folders in path
  * @return 0 on success and other value on failure
@@ -75,12 +75,21 @@ int platform_makeDir(const char *path);
 int platform_writeFile(const char *path, void *data, int size);
 
 /*!
- * Removes a file at the given path
- *
- * @param path the full path to the file to remove
- * @return 0 on success and other value on failure
- */
+* Removes a file at the given path
+*
+* @param path the full path to the file to remove
+* @return 0 on success and other value on failure
+*/
 int platform_removeFile(const char *path);
+
+/*!
+* Moves a file from source to dest
+*
+* @param source the full path of the file to move
+* @param dest the full destination path of the file
+* @return 0 on success and other value on failure
+*/
+int platform_moveFile(const char *source, const char *dest);
 
 /*!
  * Checks if a directory exists at the given path
@@ -99,13 +108,12 @@ int platform_dirExists(const char *path);
 int platform_removeDir(const char *path);
 
 /*!
- * Normalizes a path to use the system folder delimiter
+ * Normalizes a path to use the system folder delimiter.
+ * This function modifies the buffer in-place.
  *
- * @param path the full path to the directory to remove
- * @return a string with the normalized path (note that this is a shared string buffer
- * and only valid between calls)
+ * @param path Path to normalize.
  */
-const char *platform_normalizePath(const char *path);
+void platform_normalizePath(const char *path);
 
 /*!
  * Returns / or \ depending on platform.

--- a/loom/common/platform/platformIO.c
+++ b/loom/common/platform/platformIO.c
@@ -178,6 +178,11 @@ int platform_mapFileExists(const char *path)
     // Verify our dependents are good.
     ensureStartedUp();
 
+#if LOOM_PLATFORM == LOOM_PLATFORM_WIN32
+    DWORD attr = GetFileAttributes(path);
+    return attr != 0xFFFFFFFF;
+#endif
+
     // Try opening it with fopen.
     f = fopen(path, "rb");
     if (f)

--- a/loom/common/platform/platformIO.c
+++ b/loom/common/platform/platformIO.c
@@ -179,8 +179,7 @@ int platform_mapFileExists(const char *path)
     ensureStartedUp();
 
 #if LOOM_PLATFORM == LOOM_PLATFORM_WIN32
-    DWORD attr = GetFileAttributes(path);
-    return attr != 0xFFFFFFFF;
+    return GetFileAttributes(path) != 0xFFFFFFFF;
 #endif
 
     // Try opening it with fopen.

--- a/loom/script/native/core/system/Platform/lmFile.cpp
+++ b/loom/script/native/core/system/Platform/lmFile.cpp
@@ -79,6 +79,19 @@ public:
         return 1;
     }
 
+    static int moveFile(lua_State *L)
+    {
+        if (!lua_isstring(L, 1) || !lua_isstring(L, 2))
+        {
+            lua_pushboolean(L, 0);
+            return 1;
+        }
+
+        !platform_moveFile(lua_tostring(L, 1), lua_tostring(L, 2)) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+
+        return 1;
+    }
+
     static int writeBinaryFile(lua_State *L)
     {
         if (!lua_isstring(L, 1) || !lualoom_checkinstancetype(L, 2, "system.ByteArray"))
@@ -177,7 +190,11 @@ public:
             return 1;
         }
 
-        lua_pushstring(L, platform_normalizePath(lua_tostring(L, 1)));
+        static char normalized[4096];
+        strncpy(normalized, lua_tostring(L, 1), sizeof(normalized));
+        platform_normalizePath(normalized);
+        lua_pushstring(L, normalized);
+
         return 1;
     }
 
@@ -273,6 +290,7 @@ static int _registerSystemPlatform(lua_State *L)
        .addStaticLuaFunction("_writeBinaryFile", &File::writeBinaryFile)
        .addStaticLuaFunction("_fileExists", &File::fileExists)
        .addStaticLuaFunction("_removeFile", &File::removeFile)
+       .addStaticLuaFunction("_moveFile", &File::moveFile)
        .endClass()
 
        .beginClass<Path>("Path")

--- a/loom/script/native/core/system/Platform/lmFile.cpp
+++ b/loom/script/native/core/system/Platform/lmFile.cpp
@@ -43,7 +43,7 @@ public:
             return 1;
         }
 
-        platform_mapFileExists(lua_tostring(L, 1)) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, platform_mapFileExists(lua_tostring(L, 1)));
 
         return 1;
     }
@@ -61,7 +61,7 @@ public:
 
         int sz = (int)strlen(data);
 
-        !platform_writeFile(path, (void *)data, sz) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, !platform_writeFile(path, (void *)data, sz));
 
         return 1;
     }
@@ -74,7 +74,7 @@ public:
             return 1;
         }
 
-        !platform_removeFile(lua_tostring(L, 1)) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, !platform_removeFile(lua_tostring(L, 1)));
 
         return 1;
     }
@@ -87,7 +87,7 @@ public:
             return 1;
         }
 
-        !platform_moveFile(lua_tostring(L, 1), lua_tostring(L, 2)) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, !platform_moveFile(lua_tostring(L, 1), lua_tostring(L, 2)));
 
         return 1;
     }
@@ -104,7 +104,7 @@ public:
 
         const char *path = lua_tostring(L, 1);
 
-        !platform_writeFile(path, (void *)byteArray->getDataPtr(), (int)byteArray->getSize()) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, !platform_writeFile(path, (void *)byteArray->getDataPtr(), (int)byteArray->getSize()));
 
         return 1;
     }
@@ -206,7 +206,7 @@ public:
             return 1;
         }
 
-        !platform_makeDir(lua_tostring(L, 1)) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, !platform_makeDir(lua_tostring(L, 1)));
 
         return 1;
     }
@@ -219,7 +219,7 @@ public:
             return 1;
         }
 
-        !platform_dirExists(lua_tostring(L, 1)) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, !platform_dirExists(lua_tostring(L, 1)));
 
         return 1;
     }
@@ -232,7 +232,7 @@ public:
             return 1;
         }
 
-        !platform_removeDir(lua_tostring(L, 1)) ? lua_pushboolean(L, 1) : lua_pushboolean(L, 0);
+        lua_pushboolean(L, !platform_removeDir(lua_tostring(L, 1)));
 
         return 1;
     }

--- a/sdk/src/loom2d/Textures/Texture.ls
+++ b/sdk/src/loom2d/Textures/Texture.ls
@@ -556,29 +556,18 @@ package loom2d.textures
                     if(cacheOnDisk)
                     {
                         File.move(req.cacheFileName, cacheFile);
-                        //kick off the async load and return our holding texture
-                        Debug.assert(existingNativeID == -1, "Texture update from http request currently unsupported");
-                        tInfo = Texture2D.initFromAssetAsync(cacheFile, highPriority);
+                    }
+                    //load the bytes Async
+                    if (existingNativeID  == -1) {
+                        tInfo = Texture2D.initFromBytesAsync(result, urlsha2, highPriority);
                         if(tInfo == null)
                         {
-                            Console.print("WARNING: Unable to load HTTP texture from cached file: " + cacheFile); 
+                            Console.print("WARNING: Unable to load texture from bytes given data from url: " + url); 
                         }
-                    }
-                    else
-                    {
-
-                        //load the bytes Async
-                        if (existingNativeID  == -1) {
-                            tInfo = Texture2D.initFromBytesAsync(result, urlsha2, highPriority);
-                            if(tInfo == null)
-                            {
-                                Console.print("WARNING: Unable to load texture from bytes given data from url: " + url); 
-                            }
-                        } else {
-                            //Texture2D.updateFromBytes(existingNativeID, texBytes);
-                            Texture2D.updateFromBytesAsync(existingNativeID, result, highPriority);
-                            tInfo = tex.textureInfo;
-                        }                 
+                    } else {
+                        //Texture2D.updateFromBytes(existingNativeID, texBytes);
+                        Texture2D.updateFromBytesAsync(existingNativeID, result, highPriority);
+                        tInfo = tex.textureInfo;
                     }
                 }
                 

--- a/sdk/src/system/Platform/File.ls
+++ b/sdk/src/system/Platform/File.ls
@@ -90,7 +90,19 @@ package system.platform {
 
             return writeBinaryFile(Path.normalizePath(pathDestination), bytes);
         }
-
+        
+        /**
+         *  Moves a file from pathSource to pathDestination
+         *  
+         *  @param pathSource The source file to move.
+         *  @param pathDestination The destination path to move the file to.
+         *  @return True on success, false on failure.
+         */
+        public static function move(pathSource:String, pathDestination:String):Boolean
+        {
+            return _moveFile(pathSource, pathDestination);
+        }
+        
 
         /**
          *  Checks whether a file exists at the given path.
@@ -124,6 +136,8 @@ package system.platform {
         private static native function _writeBinaryFile(path:String, data:ByteArray):Boolean; 
 
         private static native function _fileExists(path:String):Boolean;
+        
+        private static native function _moveFile(source:String, dest:String):Boolean;
 
         private static native function _removeFile(path:String):Boolean;
 

--- a/tools/assetAgent/src/main.cpp
+++ b/tools/assetAgent/src/main.cpp
@@ -244,13 +244,13 @@ static int makeAssetPathCanonical(const char *pathIn, char pathOut[MAXPATHLEN])
 static bool checkInWhitelist(utString path)
 {
     // Note the platform-specific version of our whitelisted folders.
-    static utString assetPath = platform_normalizePath("./assets");
-    static utString binPath   = platform_normalizePath("./bin");
-    static utString srcPath   = platform_normalizePath("./src");
+    static utString assetPath = "./assets"; platform_normalizePath(assetPath.c_str());
+    static utString binPath   = "./bin";    platform_normalizePath(binPath.c_str());
+    static utString srcPath   = "./src";    platform_normalizePath(srcPath.c_str());
 
     // Just prefix match against assets for now - ignore things in other folders.
     lmLogDebug(gAssetAgentLogGroup, "Whitelisting path %s prefix %s\n", path.c_str(), path.substr(0, 6).c_str());
-    path = platform_normalizePath(path.c_str());
+    platform_normalizePath(path.c_str());
     if (path.substr(path.length() - 3, 3) == "tmp")
     {
         return false;

--- a/tools/assetAgent/src/main.cpp
+++ b/tools/assetAgent/src/main.cpp
@@ -244,13 +244,13 @@ static int makeAssetPathCanonical(const char *pathIn, char pathOut[MAXPATHLEN])
 static bool checkInWhitelist(utString path)
 {
     // Note the platform-specific version of our whitelisted folders.
-    static utString assetPath = "./assets"; platform_normalizePath(assetPath.c_str());
-    static utString binPath   = "./bin";    platform_normalizePath(binPath.c_str());
-    static utString srcPath   = "./src";    platform_normalizePath(srcPath.c_str());
+    static utString assetPath = "./assets"; platform_normalizePath(const_cast<char*>(assetPath.c_str()));
+    static utString binPath   = "./bin";    platform_normalizePath(const_cast<char*>(binPath.c_str()));
+    static utString srcPath   = "./src";    platform_normalizePath(const_cast<char*>(srcPath.c_str()));
 
     // Just prefix match against assets for now - ignore things in other folders.
     lmLogDebug(gAssetAgentLogGroup, "Whitelisting path %s prefix %s\n", path.c_str(), path.substr(0, 6).c_str());
-    platform_normalizePath(path.c_str());
+    platform_normalizePath(const_cast<char*>(path.c_str()));
     if (path.substr(path.length() - 3, 3) == "tmp")
     {
         return false;


### PR DESCRIPTION
Fixed platform_normalizePath so it's thread safe .. or more accurately so that the caller is responsible for safety
Added platform_moveFile and File.move that pretty much just map to the rename syscall
Fixed some copy pasted comments in platformFile.h
Added more canonical file exists for windows because I thought that was the problem and why not
Fixed so texture caching first downloads to a .part file and then renames when finished for better reliability