### PR TITLE
A bunch of camera semi-related fixes

### DIFF
--- a/application/common/core.cpp
+++ b/application/common/core.cpp
@@ -288,7 +288,7 @@ static int sdlPriorityEvents(void* userdata, SDL_Event* event)
     switch (event->type) {
         // If we don't pause immediately, the app could get killed
         // due to misbehaved processing / OpenGL activity
-        case SDL_APP_DIDENTERBACKGROUND:
+        case SDL_APP_WILLENTERBACKGROUND:
             loom_appPause();
             return false;
             

--- a/loom/common/platform/platformMobileIOS.mm
+++ b/loom/common/platform/platformMobileIOS.mm
@@ -38,9 +38,13 @@ limitations under the License.
 
 #include "loom/engine/bindings/loom/lmApplication.h"
 
-
+extern "C" {
+    void loom_appPause();
+    void loom_appResume();
+}
 
 void handleGenericEvent(void *userdata, const char *type, const char *payload);
+
 
 //interface for PlatformMobileiOS
 @interface PlatformMobileiOS : UIViewController <CLLocationManagerDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
@@ -133,6 +137,9 @@ void handleGenericEvent(void *userdata, const char *type, const char *payload);
     UIViewController *root = window.rootViewController;
     [root dismissModalViewControllerAnimated:YES];
     
+    // Resume normal operations
+    loom_appResume();
+    
     LoomApplication::fireGenericEvent("cameraSuccess", [fileSavePath UTF8String]);
 }
 
@@ -141,6 +148,9 @@ void handleGenericEvent(void *userdata, const char *type, const char *payload);
     UIWindow *window = [[UIApplication sharedApplication] keyWindow];
     UIViewController *root = window.rootViewController;
     [root dismissModalViewControllerAnimated:YES];
+    
+    // Resume normal operations
+    loom_appResume();
     
     LoomApplication::fireGenericEvent("cameraFail", "cancel");
 }
@@ -154,9 +164,12 @@ void handleGenericEvent(void *userdata, const char *type, const char *payload);
 		imagePicker.sourceType = UIImagePickerControllerSourceTypeCamera;
 		imagePicker.allowsEditing = YES;
         
+        // We can't do anything while camera is opened
+        loom_appPause();
+        
         UIWindow *window = [[UIApplication sharedApplication] keyWindow];
         UIViewController *root = window.rootViewController;
-		[root presentModalViewController:imagePicker animated:YES];
+        [root presentViewController:imagePicker animated:YES completion:nil];
 	}
 	else
 	{

--- a/loom/engine/bindings/loom/lmApplication.cpp
+++ b/loom/engine/bindings/loom/lmApplication.cpp
@@ -85,15 +85,17 @@ void loom_appSetup(void)
 
 void loom_appPause(void)
 {
-    atomic_store32(&gLoomTicking, 0);
+    int ticking = atomic_decrement(&gLoomTicking);
+    if (ticking != 0) return;
     GFX::Graphics::pause();
     lmLogInfo(applicationLogGroup, "Paused");
 }
     
 void loom_appResume(void)
 {
+    int ticking = atomic_increment(&gLoomTicking);
+    if (ticking != 1) return;
     GFX::Graphics::resume();
-    atomic_store32(&gLoomTicking, 1);
     lmLogInfo(applicationLogGroup, "Resumed");
 }
 

--- a/loom/engine/bindings/loom/lmApplicationTasks.cpp
+++ b/loom/engine/bindings/loom/lmApplicationTasks.cpp
@@ -39,7 +39,7 @@ atomic_int_t gLoomTicking = 1;
 
 void loom_tick()
 {
-    if (!atomic_load32(&gLoomTicking)) return;
+    if (atomic_load32(&gLoomTicking) < 1) return;
     
     Telemetry::beginTick();
     


### PR DESCRIPTION
Switched from didEnterBackground to willEnterBackground as that seems like the more proper place as per Apple docs
Now pausing app while camera is open (fixes GL breaking after camera closes)
gLoomTicking is now a counter to allow for multiple pause/resume calls properly pausing and resuming