### PR TITLE
In some configurations int64_t doesn't exist here so it's probably ea…

### DIFF
--- a/loom/script/native/lsLuaBridge.h
+++ b/loom/script/native/lsLuaBridge.h
@@ -2324,7 +2324,7 @@ template<> struct Stack<
     {
         // Needs to be cast to a signed int first, then to an unsigned int
         // Casting negative real numbers to unsigned int is only defined for the range (-1, UTYPE_MAX+1)
-        return static_cast<unsigned int>(static_cast<int64_t>(luaL_checknumber(L, index)));
+        return static_cast<unsigned int>(static_cast<long long>(luaL_checknumber(L, index)));
     }
 };
 


### PR DESCRIPTION
…sier to just do this instead of pulling in an include