### PR TITLE
Reverted breaking Button change, fixed TextInput focus

### DIFF
--- a/sdk/src/feathers/controls/Button.ls
+++ b/sdk/src/feathers/controls/Button.ls
@@ -445,7 +445,6 @@ package feathers.controls
             this._currentState = value;
             this.invalidate(INVALIDATION_FLAG_STATE);
             
-            this.dispatchEventWith(Event.CHANGE);
         }
 
         /**

--- a/sdk/src/feathers/controls/TextInput.ls
+++ b/sdk/src/feathers/controls/TextInput.ls
@@ -1239,25 +1239,38 @@ package feathers.controls
                 return;
             }
 
-            const touches:Vector.<Touch> = event.getTouches(this, null, HELPER_TOUCHES_VECTOR);
-            if(touches.length == 0)
-            {
-                this.textEditor.clearFocus();
-                                
-                //end hover
-                /*if(Mouse.supportsNativeCursor && this._oldMouseCursor)
-                {
-                    Mouse.cursor = this._oldMouseCursor;
-                    this._oldMouseCursor = null;
-                }*/
-                return;
+            var touch:Touch = null;
+            
+            const touches:Vector.<Touch> = event.getTouches(stage, null, HELPER_TOUCHES_VECTOR);
+            
+            if (_textEditorHasFocus) {
+                var clearFocus:Boolean = false;
+                for each(touch in touches) {
+                    if (!touch.isTouching(this) && touch.phase == TouchPhase.ENDED) {
+                        clearFocus = true;
+                        break;
+                    }
+                    
+                    //end hover
+                    /*if(Mouse.supportsNativeCursor && this._oldMouseCursor)
+                    {
+                        Mouse.cursor = this._oldMouseCursor;
+                        this._oldMouseCursor = null;
+                    }*/
+                }
+                
+                if (clearFocus) {
+                    this.textEditor.clearFocus();
+                    return;
+                }
             }
 
             if(this._touchPointID >= 0)
             {
-                var touch:Touch;
+                touch = null;
                 for each(var currentTouch:Touch in touches)
                 {
+                    if (!currentTouch.isTouching(this)) continue;
                     if(currentTouch.id == this._touchPointID)
                     {
                         touch = currentTouch;
@@ -1282,6 +1295,7 @@ package feathers.controls
             {
                 for each(touch in touches)
                 {
+                    if (!touch.isTouching(this)) continue;
                     if(touch.phase == TouchPhase.BEGAN)
                     {
                         this._touchPointID = touch.id;


### PR DESCRIPTION
Reverted `Event.CHANGE` from Button's `currentState` setter, since it breaks a bunch of stuff. There is already a CHANGE event in `isSelected` and there's also an `Event.TRIGGERED`
Reworked TextInput's focus code so it only clears focus when you click outside (and not when you just hover outside)