### PR TITLE
Add back example files needed for `loom new`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -190,10 +190,8 @@ namespace :generate do
 
       # Nuke all the garbage in the examples folders.
       Dir.glob("docs/output/examples/*/") do |exampleFolder|
-        FileUtils.rm_r "#{exampleFolder}/assets", :force => true
         FileUtils.rm_r "#{exampleFolder}/bin", :force => true
         FileUtils.rm_r "#{exampleFolder}/libs", :force => true
-        FileUtils.rm_r "#{exampleFolder}/src", :force => true
       end
 
       # make sure we don't accumulate junk in the artifacs/docs folder.

--- a/build/Swarley
+++ b/build/Swarley
@@ -179,8 +179,8 @@ namespace :package do
     # Package examples skipping bloat.
     Zip::File.open("pkg/examples.zip", 'w') do |zipfile|
       Dir["docs/examples/**/**"].each do |file|
-       next if File.extname(file) == ".loomlib"
-       next if File.extname(file) == ".loom"
+        next if File.extname(file) == ".loomlib"
+        next if File.extname(file) == ".loom"
         zipfile.add(file.sub("docs/examples/", ''),file)
       end
     end

--- a/docs/main.rb
+++ b/docs/main.rb
@@ -76,7 +76,10 @@ def copy_examples
       FileUtils.mkdir_p(File.join(OUTPUT_DIR, lib_path))
       FileUtils.cp(File.join(lib_path, "README.md"), File.join(OUTPUT_DIR, lib_path))
       FileUtils.cp(File.join(lib_path, "loom.config"), File.join(OUTPUT_DIR, lib_path))
-      FileUtils.cp(File.join(lib_path, ".gitignore"), File.join(OUTPUT_DIR, lib_path))
+      begin
+        FileUtils.cp(File.join(lib_path, ".gitignore"), File.join(OUTPUT_DIR, lib_path))
+      rescue Errno::ENOENT
+      end
       if Dir.exists? File.join(lib_path, "src")
         FileUtils.cp_r(File.join(lib_path, "src"), File.join(OUTPUT_DIR, lib_path))
       end

--- a/docs/main.rb
+++ b/docs/main.rb
@@ -83,14 +83,19 @@ def copy_examples
       if Dir.exists? File.join(lib_path, "src")
         FileUtils.cp_r(File.join(lib_path, "src"), File.join(OUTPUT_DIR, lib_path))
       end
+      if Dir.exists? File.join(lib_path, "assets")
+        FileUtils.cp_r(File.join(lib_path, "assets"), File.join(OUTPUT_DIR, lib_path))
+      end
       if Dir.exists? File.join(lib_path, "images")
         FileUtils.cp_r(File.join(lib_path, "images"), File.join(OUTPUT_DIR, lib_path))
       end
       if Dir.exists? File.join(lib_path, "icons", "ios")
-        FileUtils.cp_r(File.join(lib_path, "icons", "ios"), File.join(OUTPUT_DIR, lib_path))
+        FileUtils.mkdir_p(File.join(OUTPUT_DIR, lib_path, "icons"))
+        FileUtils.cp_r(File.join(lib_path, "icons", "ios"), File.join(OUTPUT_DIR, lib_path, "icons"))
       end
       if Dir.exists? File.join(lib_path, "icons", "android")
-        FileUtils.cp_r(File.join(lib_path, "icons", "android"), File.join(OUTPUT_DIR, lib_path))
+        FileUtils.mkdir_p(File.join(OUTPUT_DIR, lib_path, "icons"))
+        FileUtils.cp_r(File.join(lib_path, "icons", "android"), File.join(OUTPUT_DIR, lib_path, "icons"))
       end
       example_doc = Module::ExampleDoc.new(lib_path.split("/").last)
       puts "Processing #{example_doc.path}.."

--- a/docs/main.rb
+++ b/docs/main.rb
@@ -74,12 +74,20 @@ def copy_examples
   Dir["examples/*"].each do |lib_path|
     if File.exists? File.join(lib_path, "README.md")
       FileUtils.mkdir_p(File.join(OUTPUT_DIR, lib_path))
-      FileUtils.cp_r(File.join(lib_path, "README.md"), File.join(OUTPUT_DIR, lib_path))
+      FileUtils.cp(File.join(lib_path, "README.md"), File.join(OUTPUT_DIR, lib_path))
+      FileUtils.cp(File.join(lib_path, "loom.config"), File.join(OUTPUT_DIR, lib_path))
+      FileUtils.cp(File.join(lib_path, ".gitignore"), File.join(OUTPUT_DIR, lib_path))
       if Dir.exists? File.join(lib_path, "src")
         FileUtils.cp_r(File.join(lib_path, "src"), File.join(OUTPUT_DIR, lib_path))
       end
       if Dir.exists? File.join(lib_path, "images")
         FileUtils.cp_r(File.join(lib_path, "images"), File.join(OUTPUT_DIR, lib_path))
+      end
+      if Dir.exists? File.join(lib_path, "icons", "ios")
+        FileUtils.cp_r(File.join(lib_path, "icons", "ios"), File.join(OUTPUT_DIR, lib_path))
+      end
+      if Dir.exists? File.join(lib_path, "icons", "android")
+        FileUtils.cp_r(File.join(lib_path, "icons", "android"), File.join(OUTPUT_DIR, lib_path))
       end
       example_doc = Module::ExampleDoc.new(lib_path.split("/").last)
       puts "Processing #{example_doc.path}.."


### PR DESCRIPTION
After landing, the following steps shouldn't fail anymore:
* `loom new MyThrusties --example Thrusties --firehose`
  * should download the latest firehose (this branch after it gets landed and built)
  * should create a new example dir called MyThrusties and copy the Thrusties example from firehose into it
* `cd MyThrusties` and `loom run` should run the example successfully (loom.config, assets and source should all be present for this to work)