### PR TITLE
Telemetry and bug fix extravaganza

### DIFF
--- a/application/android/src/co/theengine/loomplayer/LoomHTTP.java
+++ b/application/android/src/co/theengine/loomplayer/LoomHTTP.java
@@ -185,17 +185,14 @@ public class LoomHTTP
             
                 if (savedFile != null)
                 {
-                    Log.d(TAG, "Caching HTTP response to '" + responseCacheFile + "'");
                     try {
                         BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(savedFile));
                         bos.write(binaryData);
                         bos.flush();
                         bos.close();
-                        Log.d(TAG, "File written...");
                     }
                     catch (Exception e)
                     {
-                        Log.e(TAG, "File write failed...");
                         throw new AssertionError("HTTP Response could not be cached.");
                     }
                 }
@@ -215,7 +212,6 @@ public class LoomHTTP
             @Override
             public void onCancel()
             {
-                Log.i(TAG, index+" cancel response");
             }
             
         };
@@ -295,14 +291,11 @@ public class LoomHTTP
                 failure("exception caught while posting request: " + e + errors.toString());
             }
             
-            Log.d(TAG, index + " send running");
-            
         }
         
         
         protected void success(final byte[] response)
         {
-            Log.d(TAG, index + " send success");
             if (response == null) Log.w(TAG, index + " send success response null!");
             final int index = this.index;
             final long callback = this.callback;
@@ -311,7 +304,6 @@ public class LoomHTTP
             activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    Log.d(TAG, index + " main success " + response.length + " bytes, callback=" + callback + " payload=" + payload);
                     if (callback != -1 && payload != -1) {
                         LoomHTTP.onSuccess(response, callback, payload);
                         LoomHTTP.complete(index);
@@ -332,7 +324,7 @@ public class LoomHTTP
         {
             if (response == null) Log.w(TAG, index + " send failure response null!");
             final byte[] binaryData = response == null ? new byte[0] : response;
-            Log.d(TAG, index + " send failure");
+            Log.w(TAG, index + " send failure");
             final int index = this.index;
             final long callback = this.callback;
             final long payload = this.payload;
@@ -350,10 +342,8 @@ public class LoomHTTP
         
         protected void cancel()
         {
-            Log.d(TAG, index + " cancel received");
             if (requestHandle == null) return;
             boolean success = requestHandle.cancel(true);
-            Log.d(TAG, index + " cancel finished="+success);
             finish();
         }
         
@@ -369,7 +359,6 @@ public class LoomHTTP
             followRedirects = false;
             requestHandle = null;
             savedFile = null;
-            Log.d(TAG, index + " finished");
         }
         
         
@@ -382,7 +371,6 @@ public class LoomHTTP
     public static boolean cancel(int index)
     {
         if (index == -1) return false;
-        Log.d(TAG, index + " cancel requested");
         SendTask st = tasks[index];
         if (!st.busy) return false;
         background.cancel(st);

--- a/application/common/core.cpp
+++ b/application/common/core.cpp
@@ -27,6 +27,7 @@
 #include "loom/common/core/log.h"
 #include "loom/common/platform/platform.h"
 #include "loom/common/platform/platformMobile.h"
+#include "loom/common/core/telemetry.h"
 
 #include "loom/engine/bindings/sdl/lmSDL.h"
 #include "loom/engine/bindings/loom/lmGameController.h"
@@ -93,6 +94,10 @@ static const char* getSDLEventName(const SDL_Event* event)
 
 void loop()
 {
+    Telemetry::beginTick();
+
+    LOOM_PROFILE_START(loom_events);
+
     SDL_Event event;
 
     // Get the stage as it will receive most events.
@@ -298,8 +303,14 @@ void loop()
         }
     }
 
+    LOOM_PROFILE_END(loom_events);
+
     /* Tick and render Loom. */
     loom_tick();
+
+    LOOM_PROFILE_ZERO_CHECK()
+
+    Telemetry::endTick();
 }
 
 static void sdlLogOutput(void* userdata, int category, SDL_LogPriority priority, const char* message)

--- a/loom/common/CMakeLists.txt
+++ b/loom/common/CMakeLists.txt
@@ -3,7 +3,7 @@ set (TARGET_NAME LoomCommon)
 include_directories( ${LOOM_INCLUDE_FOLDERS} )
 
 # Define source files
-file (GLOB CPP_FILES xml/*.cpp utils/*.cpp core/*.cpp core/*.c platform/*.cpp platform/*.c config/*.cpp)
+file (GLOB CPP_FILES xml/*.cpp utils/*.cpp utils/*.c core/*.cpp core/*.c platform/*.cpp platform/*.c config/*.cpp)
 file (GLOB H_FILES utils/*.h xml/*.h platform/*.h assets/*.c assets/*.cpp)
 
 if (APPLE)

--- a/loom/common/assets/assetProtocol.h
+++ b/loom/common/assets/assetProtocol.h
@@ -23,6 +23,7 @@
 #define _ASSETS_ASSETPROTOCOL_H_
 
 #include "loom/common/platform/platformNetwork.h"
+#include "loom/common/platform/platformTime.h"
 #include "loom/common/utils/utString.h"
 
 // Helper class to handle reading/writing asset protocol data.
@@ -43,6 +44,9 @@ public:
 
     int readInt();
     void writeInt(int _value);
+
+    UTuint64 readUInt64();
+    void writeUInt64(UTuint64 _value);
 
     double readDouble();
     void writeDouble(double _value);
@@ -87,12 +91,12 @@ class AssetProtocolHandler
 public:
 
     NetworkBuffer buffer;
-    int           bytesLength;
-    unsigned char *bytes;
 
     loom_socketId_t socket;
+    loom_precision_timer_t lastActiveTime;
 
     bool readFrame();
+    void freeBuffer();
 
     AssetProtocolMessageListener *listenerHead;
 

--- a/loom/common/core/performance.h
+++ b/loom/common/core/performance.h
@@ -191,6 +191,7 @@ struct LoomProfilerRoot
     bool                    mTelemetryVisited;
 
     static LoomProfilerRoot *sRootList;
+    static void* sRootLookup;
     // Returns the profiler root with this name or a new one if one doesn't
     // exist yet.  
     static LoomProfilerRoot* fromName(const char *name);

--- a/loom/common/core/performance.h
+++ b/loom/common/core/performance.h
@@ -188,8 +188,12 @@ struct LoomProfilerRoot
     F64                     mMinTime;
     U32                     mTotalInvokeCount;
     bool                    mEnabled;
+    bool                    mTelemetryVisited;
 
     static LoomProfilerRoot *sRootList;
+    // Returns the profiler root with this name or a new one if one doesn't
+    // exist yet.  
+    static LoomProfilerRoot* fromName(const char *name);
 
     LoomProfilerRoot(const char *name);
 };

--- a/loom/common/core/telemetry.cpp
+++ b/loom/common/core/telemetry.cpp
@@ -2,8 +2,9 @@
 
 #include "loom/common/assets/assets.h"
 #include "loom/common/core/log.h"
-#include "loom/common/core/performance.h"
 #include "loom/common/utils/fourcc.h"
+#include "loom/common/utils/utEndian.h"
+#include "loom/common/platform/platformThread.h"
 
 lmDefineLogGroup(gTelemetryLogGroup, "lt", true, LoomLogInfo)
 
@@ -17,8 +18,11 @@ int Telemetry::tickId = 0;
 TableValues<TickMetricValue> Telemetry::tickValues;
 
 loom_precision_timer_t Telemetry::tickTimer = loom_startTimer();
-utArray<utString> Telemetry::tickTimerStack;
-TableValues<TickMetricRange> Telemetry::tickRanges;
+
+int Telemetry::tickProfilerRootsVisited;
+size_t Telemetry::eventsStartPos;
+bool Telemetry::tickProfilerActive = false;
+int Telemetry::tickThreadId = -1;
 
 // Initialize specialized constants for every type used
 // TickMetricValue
@@ -26,8 +30,10 @@ template<> const TableType TableValues<TickMetricValue>::type = 1;
 template<> const int TableValues<TickMetricValue>::packedItemSize = 4 + 8;
 // TickMetricRange
 template<> const TableType TableValues<TickMetricRange>::type = 2;
-template<> const int TableValues<TickMetricRange>::packedItemSize = 4 + 4 * 4 + 2 * 8;
+template<> const int TableValues<TickMetricRange>::packedItemSize = 4 + 4 * 4 + 3 * 8;
 
+static const int EVENT_BYTE_SIZE = 16;
+static const size_t EVENTS_MIN_SIZE = EVENT_BYTE_SIZE*128;
 
 void Telemetry::enable()
 {
@@ -42,133 +48,277 @@ void Telemetry::disable()
 void Telemetry::beginTick()
 {
     if (enabled != pendingEnabled) {
+        if (pendingEnabled) tickThreadId = platform_getCurrentThreadId();
         enabled = pendingEnabled;
         lmLog(gTelemetryLogGroup, "Telemetry %s", enabled ? "enabled" : "disabled");
     }
     if (!enabled) return;
 
     tickValues.reset();
-    tickRanges.reset();
-    tickTimerStack.clear();
+    tickProfilerRootsVisited = 0;
 
     loom_resetTimer(tickTimer);
 
+    // Customized asset protocol message (3 ints + telemetry + other tables)
+    sendBuffer.setPosition(0);
+
+    // Size of the whole message, late write
+    sendBuffer.writeUnsignedInt(-1);
+    sendBuffer.writeInt(0xDEADBEEF);
+    sendBuffer.writeInt(LOOM_FOURCC('T', 'E', 'L', 'E'));
+
+    // Size of telemetry events, late write
+    sendBuffer.writeUnsignedInt(-1); 
+
+    // Endianness of the device for more efficient recording
+    sendBuffer.writeUnsignedInt(UT_ENDIAN);
+
+    // Event stream starting point for later use
+    eventsStartPos = sendBuffer.getPosition();
+
     // Add the tick id as a default tick value
     setTickValue("tick.id", tickId);
+
+    tickProfilerActive = true;
+}
+
+// Used to build up a telemetry root structure while reading.
+struct TickProfilerRoot {
+    utString name;
+    int count;
+};
+
+bool Telemetry::readTickProfiler(utByteArray& buffer, JSON& ranges, JSON& meta)
+{
+    loom_resetTimer(tickTimer);
+
+    size_t eventsSize = buffer.readUnsignedInt();
+    unsigned int eventEndianness = buffer.readUnsignedInt();
+    size_t eventsPos = buffer.getPosition();
+    
+    // Skip to the profiler root tree
+    buffer.setPosition(eventsPos + eventsSize);
+
+    utHashTable<utUInt64HashKey, TickProfilerRoot> addrToName;
+
+    // Read the profiler roots and save them as a lookup table into `addrToName`
+    UTuint64 addr = -1;
+    while ((addr = buffer.readUnsignedInt64()) != 0) {
+        TickProfilerRoot root;
+        root.name = buffer.readString();
+        root.count = 0;
+        addrToName.insert(utUInt64HashKey(addr), root);
+    }
+    // Overhead while writing the lookup table in-app
+    UTuint64 writeOverhead = buffer.readUnsignedInt64();
+
+    // Remember the end of the tick profiling data
+    size_t endPos = buffer.getPosition();
+
+    // Skip back to telemetry events
+    buffer.setPosition(eventsPos);
+
+    ranges.initArray();
+
+    UTuint64 addrWithType;
+    int sequence = 0;
+
+    utArray<int> ancestors;
+    ancestors.push_back(-1);
+
+    // Read, process and write events as JSON
+    while ((addrWithType = buffer.readUnsignedInt64()) != 0) {
+        UTint64 nanoTime = buffer.readUnsignedInt64();
+
+        // Convert endianness if necessary
+        if (eventEndianness == UT_ENDIAN_BIG)
+        {
+            addrWithType = convertBEndianToHost(addrWithType);
+            nanoTime = convertBEndianToHost(nanoTime);
+        }
+        else
+        {
+            addrWithType = convertLEndianToHost(addrWithType);
+            nanoTime = convertLEndianToHost(nanoTime);
+        }
+
+        // Grab address and type from the combined addrWithType
+        UTuint64 addr = addrWithType & ~TICK_EVENT_ALIGN_MASK;
+        unsigned char type = addrWithType & TICK_EVENT_ALIGN_MASK;
+
+        TickProfilerRoot* rootPtr = addrToName.get(addr);
+        lmAssert(rootPtr, "Unable to find event profiler root in lookup table: %llx", addr);
+        TickProfilerRoot& root = *rootPtr;
+
+        switch (type)
+        {
+        case TICK_EVENT_BEGIN:
+        {
+            int id = sequence++;
+            int parent = ancestors.back();
+            int sibling = root.count++;
+
+            // Increment children count in parent if there is one
+            if (parent != -1) {
+                JSON jparent = ranges.getArrayObject(parent);
+                jparent.setInteger("children", jparent.getInteger("children") + 1);
+            }
+
+            JSON jrange;
+            jrange.initObject();
+            jrange.setInteger("id", id);
+            jrange.setString("name", root.name.c_str());
+            jrange.setInteger("parent", parent);
+            jrange.setInteger("level", ancestors.size() - 1);
+            jrange.setInteger("children", 0); // Children increment themselves
+            jrange.setInteger("sibling", sibling);
+            jrange.setNumber("a", nanoTime);
+            jrange.setNumber("b", 0); // Set at TICK_EVENT_END
+            jrange.setNumber("overhead", 0);
+            ranges.setArrayObject(id, &jrange);
+
+            ancestors.push_back(id);
+        }
+        break;
+
+        case TICK_EVENT_END:
+        {
+            // Set end time in the previously started event
+            int id = ancestors.back();
+            JSON jrange = ranges.getArrayObject(id);
+            jrange.setNumber("b", nanoTime);
+
+            lmAssert(ancestors.size() > 1, "Unable to end event for %s, not enough begin events", root.name.c_str());
+            ancestors.pop_back();
+        }
+        break;
+
+        default: lmAssert(false, "Unknown telemetry profiler type: %d", type);
+        }
+
+    }
+
+    lmAssert(buffer.getPosition() - eventsPos == eventsSize, "Telemetry tick profiler read size inconsistency, expected %d read %d", eventsSize, buffer.getPosition() - eventsPos);
+
+    // Skip to end of profiler data
+    buffer.setPosition(endPos);
+
+    JSON metaOverhead;
+    metaOverhead.initObject();
+    meta.initObject();
+
+    UTint64 readOverhead = loom_readTimerNano(tickTimer);
+
+    // Write out metadata (write / read overhead)
+    metaOverhead.setNumber("write", writeOverhead);
+    metaOverhead.setNumber("read", readOverhead);
+    meta.setObject("overhead", &metaOverhead);
+
+    return true;
 }
 
 void Telemetry::endTick()
 {
     if (!enabled) return;
 
-    lmAssert(tickTimerStack.size() == 0, "Tick timer end call missing");
+    tickProfilerActive = false;
 
-    // Customized asset protocol message (3 ints + tables)
-    int sendSize = (int)(3 * 4 + tickValues.size + tickRanges.size);
-    sendBuffer.resize(sendSize);
-    sendBuffer.setPosition(0);
-    sendBuffer.writeInt(sendSize);
-    sendBuffer.writeInt(0xDEADBEEF);
-    sendBuffer.writeInt(LOOM_FOURCC('T', 'E', 'L', 'E'));
+    // End events with a zero int64
+    sendBuffer.writeUnsignedInt64(0);
 
+    // Go back and write the correct size of the events
+    size_t eventsAfterPos = sendBuffer.getPosition();
+    sendBuffer.setPosition(eventsStartPos - 4*2);
+    size_t eventsSize = eventsAfterPos - eventsStartPos;
+    sendBuffer.writeUnsignedInt(eventsSize);
+    sendBuffer.setPosition(eventsAfterPos);
+
+    // Write out all the relevant profiler roots
+    size_t rootsWalked = 0;
+    UTint64 rootWalkTime = loom_readTimerNano(tickTimer);
+    for (LoomProfilerRoot *walk = LoomProfilerRoot::sRootList; walk; walk = walk->mNextRoot)
+    {
+        rootsWalked++;
+        if (!walk->mTelemetryVisited) continue;
+
+        walk->mTelemetryVisited = false;
+
+        sendBuffer.writeUnsignedInt64(reinterpret_cast<UTuint64>(walk));
+        sendBuffer.writeString(walk->mName);
+    }
+
+    // End with a zero int64
+    sendBuffer.writeUnsignedInt64(0);
+
+    // Record the write overhead
+    rootWalkTime = loom_readTimerNano(tickTimer) - rootWalkTime;
+    sendBuffer.writeUnsignedInt64(rootWalkTime);
+
+    // Write out the values table
     tickValues.write(&sendBuffer);
-    tickRanges.write(&sendBuffer);
+
+    // Fix message size to be the actual written size
+    size_t sendSize = sendBuffer.getPosition();
+    sendBuffer.setPosition(0);
+    sendBuffer.writeUnsignedInt(sendSize);
+    sendBuffer.setPosition(sendSize);
 
     // Send the tick over the asset protocol
-    loom_asset_custom(sendBuffer.getDataPtr(), sendBuffer.getSize());
+    loom_asset_custom(sendBuffer.getDataPtr(), sendSize);
 
     tickId++;
 }
 
-void Telemetry::beginTickTimer(const char *name)
+// Ensure that the message buffer contains enough space for at least
+// one more event.
+static void ensureEventBuffer(utByteArray &buffer, size_t startPos)
 {
-    if (!enabled) return;
-
-    utHashedString key = utHashedString(name);
-
-    TickMetricRange *stored = tickRanges.table.get(key);
-
-    const int uniqueLen = 128;
-    static char uniqueName[uniqueLen];
-    int dup = 0;
-
-    // A range with the specified name already exists,
-    // mark this one as a duplicate and append the sequential duplicate number at the end
-    if (stored != NULL)
-    {
-        stored->duplicates++;
-        stored->duplicatesOnStack++;
-        snprintf(uniqueName, uniqueLen - 1, "%s #%d", name, stored->duplicates+1);
-        uniqueName[uniqueLen - 1] = 0;
-
-        key = utHashedString(uniqueName);
+    size_t size = buffer.getSize();
+    if (buffer.getPosition() + EVENT_BYTE_SIZE > size) {
+        size_t newEventsSize = utMax((size - startPos)*2, EVENTS_MIN_SIZE);
+        buffer.resize(size + newEventsSize);
     }
-
-    utString parentName = tickTimerStack.size() > 0 ? tickTimerStack.back() : NULL;
-    TickMetricRange *parent = tickRanges.table.get(utHashedString(parentName));
-
-    // Init values of the new metric based on its parent and siblings
-    TickMetricRange metric;
-    metric.id = tickRanges.sequence++;
-    lmAssert(metric.id >= 0, "Invalid id");
-    metric.parent = parent ? parent->id : -1;
-    metric.level = parent ? parent->level + 1 : 0;
-    metric.children = 0;
-    metric.sibling = parent ? parent->children : 0;
-    metric.duplicates = 0;
-    metric.duplicatesOnStack = 0;
-    if (parent) parent->children++;
-
-    // Insert it into the table
-    bool inserted = tickRanges.table.insert(key, metric);
-    lmAssert(inserted, "Tick timer insertion error");
-
-    // String written size is short length + data
-    int strSize = (int)(2 + strlen(key.str().c_str()));
-    tickRanges.size += strSize + TableValues<TickMetricRange>::packedItemSize;
-    
-    // This should be fairly quick as the last inserted value should be cached
-    stored = tickRanges.table.get(key);
-    tickTimerStack.push_back(key.str());
-
-    double tickNano = loom_readTimerNano(tickTimer);
-    
-    // Set the start time at the very end
-    // TODO measure overhead of the code above and include that in the metrics
-    stored->a = tickNano;
 }
 
-void Telemetry::endTickTimer(const char *name)
+// Begins the profiling range of the provided root.
+void Telemetry::beginTickTimer(LoomProfilerRoot* root)
 {
     if (!enabled) return;
-
-    double tickNano = loom_readTimerNano(tickTimer);
-
-    utHashedString key = utHashedString(name);
-
-    lmAssert(tickTimerStack.size() > 0, "Tick timer %s begin call missing (stack empty)");
-
-    TickMetricRange *stored = tickRanges.table.get(key);
-    utString stackedName = tickTimerStack.back();
-    TickMetricRange *stacked = tickRanges.table.get(utHashedString(stackedName));
-
-    lmAssert(stored->id >= 0 && stacked->id >= 0, "Invalid id");
-    lmAssert(stored != NULL && stacked != NULL, "Tick timer %s begin call missing");
     
-    // If the stack and stored ids don't match
-    // it means the stack metric was a modified duplicate
-    // with a different unique name, so we can decrement the
-    // number of duplicates on stack of the originally named stored metric
-    if (stored->id != stacked->id) {
-        stored->duplicatesOnStack--;
-        lmAssert(stored->duplicatesOnStack >= 0, "Tick metric mismatched begin/end calls");
+    // Ignore all events that are not on the main thread for now
+    if (platform_getCurrentThreadId() != tickThreadId) return;
+
+    // Uncomment to identify profiler events out of the usual tick range
+    //lmAssert(tickProfilerActive, "Began tick timer while inactive at %s", root->mName);
+    if (!tickProfilerActive) return;
+
+    if (!root->mTelemetryVisited) {
+        ++tickProfilerRootsVisited;
+        root->mTelemetryVisited = true;
     }
 
-    tickTimerStack.pop_back();
-    
-    // Set the end time of the tick on the stack taken from the enter time of the function
-    // TODO measure overhead as with begin
-    stacked->b = tickNano;
+    ensureEventBuffer(sendBuffer, eventsStartPos);
+
+    // Write out the event message directly in system endianness
+    UTuint64* buf = reinterpret_cast<UTuint64*>(static_cast<unsigned char*>(sendBuffer.getDataPtr()) + sendBuffer.getPosition());
+    buf[0] = reinterpret_cast<UTuint64>(root) | TICK_EVENT_BEGIN;
+    buf[1] = loom_readTimerNano(tickTimer);
+    sendBuffer.setPosition(sendBuffer.getPosition() + EVENT_BYTE_SIZE);
+}
+
+// Ends the timing range of the provided root. See `beginTickTimer`.
+void Telemetry::endTickTimer(LoomProfilerRoot* root)
+{
+    if (!enabled) return;
+    if (platform_getCurrentThreadId() != tickThreadId) return;
+    if (!tickProfilerActive) return;
+
+    ensureEventBuffer(sendBuffer, eventsStartPos);
+
+    UTuint64* buf = reinterpret_cast<UTuint64*>(static_cast<unsigned char*>(sendBuffer.getDataPtr()) + sendBuffer.getPosition());
+    buf[0] = reinterpret_cast<UTuint64>(root) | TICK_EVENT_END;
+    buf[1] = loom_readTimerNano(tickTimer);
+    sendBuffer.setPosition(sendBuffer.getPosition() + EVENT_BYTE_SIZE);
 }
 
 TickMetricValue* Telemetry::setTickValue(const char *name, double value)

--- a/loom/common/core/telemetry.h
+++ b/loom/common/core/telemetry.h
@@ -75,67 +75,6 @@ struct TickMetricValue : TickMetricBase
     }
 };
 
-// Metric type containing a floating point range with additional
-// hierarchical information meant for a hierarchy of timing ranges
-struct TickMetricRange : TickMetricBase
-{
-    // The ID of the parent metric (-1 if it's a root)
-    TickMetricID parent;
-
-    // Hierarchical level of the metric (how many parents it has)
-    int level;
-
-    // The number of direct children of this metric (only one level deep)
-    int children;
-
-    // The sequential sibling index of this metric (e.g. 2 means this is the third sibling if its parent)
-    int sibling;
-
-    // First value of the range metric (e.g. start time)
-    double a;
-
-    // Second value of the range metric (e.g. end time)
-    double b;
-
-    // The number of additional similar metrics there are in total
-    // This is useful for e.g. counting metrics with the same name
-    // and assigning them a different name for differentiation
-    int duplicates;
-    // Same as above, but meant for counting the duplicates on the stack
-    int duplicatesOnStack;
-
-    void write(utByteArray *buffer)
-    {
-        TickMetricBase::write(buffer);
-        buffer->writeInt(parent);
-        buffer->writeInt(level);
-        buffer->writeInt(children);
-        buffer->writeInt(sibling);
-        buffer->writeDouble(a);
-        buffer->writeDouble(b);
-    }
-    void writeJSON(JSON *json)
-    {
-        TickMetricBase::writeJSON(json);
-        json->setInteger("parent", parent);
-        json->setInteger("level", level);
-        json->setInteger("children", children);
-        json->setInteger("sibling", sibling);
-        json->setNumber("a", a);
-        json->setNumber("b", b);
-    }
-    void read(utByteArray *buffer)
-    {
-        TickMetricBase::read(buffer);
-        parent = buffer->readInt();
-        level = buffer->readInt();
-        children = buffer->readInt();
-        sibling = buffer->readInt();
-        a = buffer->readDouble();
-        b = buffer->readDouble();
-    }
-};
-
 // Type alias for the table type ID
 typedef unsigned char TableType;
 

--- a/loom/common/platform/platform.cpp
+++ b/loom/common/platform/platform.cpp
@@ -28,6 +28,8 @@ extern "C" {
 
 int platform_openURL(const char *url)
 {
+// Casting to int here is the right thing to do based on the func docs
+#pragma warning ( suppress: 4311, 4302 )
     return (int)ShellExecute(NULL, "open", url, NULL, NULL, SW_SHOWNORMAL) > 32;
 }
 

--- a/loom/common/platform/platformNetwork.c
+++ b/loom/common/platform/platformNetwork.c
@@ -113,14 +113,21 @@ static loom_precision_timer_t pumpTimer = NULL;
 
 int loom_net_initialize()
 {
+    // Platform-specific declarations
+#if LOOM_PLATFORM == LOOM_PLATFORM_WIN32
+    WSADATA wsaData;
+    WORD    wVersionRequested;
+    int     err;
+#endif
+    
+    // Cross-platform init
     writeMutex = loom_mutex_create();
     if (!pumpTimer) pumpTimer = loom_startTimer();
 
-    // Platform-specific init.
+    // Platform-specific init
 #if LOOM_PLATFORM == LOOM_PLATFORM_WIN32
-    WSADATA wsaData;
-    WORD    wVersionRequested = MAKEWORD(2, 0);
-    int     err = WSAStartup(wVersionRequested, &wsaData);
+    wVersionRequested = MAKEWORD(2, 0);
+    err = WSAStartup(wVersionRequested, &wsaData);
     if (err != 0)
     {
         lmLogError(netLogGroup, "Failed WinSock initalization with error %d", err);
@@ -139,15 +146,13 @@ int loom_net_initialize()
     lmAssert(sizeof(SOCKET) <= sizeof(loom_socketId_t), "Can't pack a SOCKET into loom_socketId_t");
 
     lmLogDebug(netLogGroup, "Initialized WinSock");
-    
-    return 1;
-
 #else
     // Ignore sigpipe.
     lmLogDebug(netLogGroup, "Disabling signal SIGPIPE");
     signal(SIGPIPE, SIG_IGN);
-    return 1;
 #endif
+
+    return 1;
 }
 
 

--- a/loom/common/platform/platformNetwork.c
+++ b/loom/common/platform/platformNetwork.c
@@ -66,12 +66,27 @@ typedef int   SOCKET;
 
 lmDefineLogGroup(netLogGroup, "net", 1, LoomLogWarn);
 
+// Defines how many milliseconds to sleep for if the non-blocking read failed.
 static const int readSpinSleepMs = 5;
+
+// Defines how many approx. milliseconds to wait for on a
+// stalled (no reads made) socket before timing out.
 static const int readSpinTimeoutMs = 6000;
+
+// The maximum number of bytes to send with one syscall at a time.
 static const int writeChunkMaxSize = 16384;
-static const int writeSmallCountThreshold = 200;
+
+// Power of two to round up to when growing the write buffer, e.g. 12 = 4KiB
 static const int writeResizePagePower = 12;
+
+// How many times does the total size of the buffer have to exceed the 
+// used size for the write to be considered a "small write".
 static const int writeShrinkThreshold = 3;
+
+// Defines the number of consecutive small writes triggering buffer shrinkage.
+static const int writeSmallCountThreshold = 200;
+
+// How many times the used size the buffer resizes to while shrinking.
 static const int writeShrinkTarget = 2;
 
 // Structure keeping socket buffers and metadata

--- a/loom/common/platform/platformNetwork.h
+++ b/loom/common/platform/platformNetwork.h
@@ -39,6 +39,7 @@ void loom_net_enableSocketKeepalive(loom_socketId_t s);
 
 void loom_net_readTCPSocket(loom_socketId_t s, void *buffer, int *bytesToRead, int peek);
 int loom_net_writeTCPSocket(loom_socketId_t s, void *buffer, int bytesToWrite);
+void loom_net_pump();
 
 void loom_net_getSocketPeerName(loom_socketId_t s, int *hostIp, int *hostPort);
 int loom_net_isSocketWritable(loom_socketId_t s);

--- a/loom/common/platform/platformTime.c
+++ b/loom/common/platform/platformTime.c
@@ -195,8 +195,6 @@ typedef struct timespec   loom_linux_precisionTimer_t; // Don't bother creating 
 #define WHICH_CLOCK CLOCK_REALTIME 
 #endif
 
-#include <android/log.h>
-
 void platform_timeInitialize()
 {
     // Store the current time as our dawn moment.

--- a/loom/common/platform/platformTime.c
+++ b/loom/common/platform/platformTime.c
@@ -83,12 +83,12 @@ int loom_readTimer(loom_precision_timer_t timer)
     return b;
 }
 
-uint64_t loom_readTimerNano(loom_precision_timer_t timer)
+long long loom_readTimerNano(loom_precision_timer_t timer)
 {
     loom_mach_precisionTimer_t *t = timer;
     uint64_t a = mach_absolute_time() - t->start;
     uint64_t b = (a * t->info.numer) / t->info.denom;
-    return b;
+    return (long long)b;
 }
 
 

--- a/loom/common/platform/platformTime.c
+++ b/loom/common/platform/platformTime.c
@@ -83,12 +83,12 @@ int loom_readTimer(loom_precision_timer_t timer)
     return b;
 }
 
-double loom_readTimerNano(loom_precision_timer_t timer)
+uint64_t loom_readTimerNano(loom_precision_timer_t timer)
 {
     loom_mach_precisionTimer_t *t = timer;
     uint64_t a = mach_absolute_time() - t->start;
     uint64_t b = (a * t->info.numer) / t->info.denom;
-    return (double) b;
+    return b;
 }
 
 
@@ -155,14 +155,14 @@ int loom_readTimer(loom_precision_timer_t timer)
     return (int)elapsed;
 }
 
-double loom_readTimerNano(loom_precision_timer_t timer)
+long long loom_readTimerNano(loom_precision_timer_t timer)
 {
-    double elapsed = 0.f;
+    long long elapsed = 0L;
     loom_win32_precisionTimer_t *t = (void *)timer;
     LARGE_INTEGER               endCount;
 
     QueryPerformanceCounter(&endCount);
-    elapsed = 1e9 * ((double)(endCount.QuadPart - t->mPerfCountCurrent.QuadPart) / (double)t->mFrequency.QuadPart);
+    elapsed = (endCount.QuadPart - t->mPerfCountCurrent.QuadPart)*1000000000L / t->mFrequency.QuadPart;
     return elapsed;
 }
 
@@ -179,7 +179,7 @@ void loom_destroyTimer(loom_precision_timer_t timer)
 
 #include <time.h>
 int timespecDelta(struct timespec *then, struct timespec *now);
-double timespecDeltaNano(struct timespec *then, struct timespec *now);
+long long timespecDeltaNano(struct timespec *then, struct timespec *now);
 
 struct timespec dawn;
 
@@ -194,6 +194,8 @@ typedef struct timespec   loom_linux_precisionTimer_t; // Don't bother creating 
 #else
 #define WHICH_CLOCK CLOCK_REALTIME 
 #endif
+
+#include <android/log.h>
 
 void platform_timeInitialize()
 {
@@ -235,7 +237,7 @@ int loom_readTimer(loom_precision_timer_t timer)
     return timespecDelta(t, &now);
 }
 
-double loom_readTimerNano(loom_precision_timer_t timer)
+long long loom_readTimerNano(loom_precision_timer_t timer)
 {
     struct timespec             now;
     loom_linux_precisionTimer_t *t = (loom_linux_precisionTimer_t *)timer;
@@ -264,12 +266,12 @@ int timespecDelta(struct timespec *then, struct timespec *now)
     return deltaSec * 1000 + deltaNSec / (1000 * 1000);
 }
 
-double timespecDeltaNano(struct timespec *then, struct timespec *now)
+long long timespecDeltaNano(struct timespec *then, struct timespec *now)
 {
     long deltaSec, deltaNSec;
     timespecDeltaComp(then, now, &deltaSec, &deltaNSec);
-
-    return deltaSec * 1e9 + deltaNSec;
+    
+    return (long long)deltaSec * (long long)1000000000L + (long long)deltaNSec;
 }
 
 

--- a/loom/common/platform/platformTime.h
+++ b/loom/common/platform/platformTime.h
@@ -34,7 +34,7 @@ typedef void * loom_precision_timer_t;
 loom_precision_timer_t loom_startTimer();
 void loom_resetTimer(loom_precision_timer_t timer);
 int loom_readTimer(loom_precision_timer_t timer);
-double loom_readTimerNano(loom_precision_timer_t timer);
+long long loom_readTimerNano(loom_precision_timer_t timer);
 void loom_destroyTimer(loom_precision_timer_t timer);
 
 #ifdef __cplusplus

--- a/loom/common/utils/bipbuffer.c
+++ b/loom/common/utils/bipbuffer.c
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2011, Willem-Hendrik Thiart
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ *
+ * @file
+ * @author  Willem Thiart himself@willemthiart.com
+ */
+
+#include "stdio.h"
+#include <stdlib.h>
+
+/* for memcpy */
+#include <string.h>
+
+#include "bipbuffer.h"
+
+size_t bipbuf_sizeof(const unsigned int size)
+{
+    return sizeof(bipbuf_t) + size;
+}
+
+int bipbuf_unused(const bipbuf_t* me)
+{
+    if (1 == me->b_inuse)
+        /* distance between region B and region A */
+        return me->a_start - me->b_end;
+    else
+        return me->size - me->a_end;
+}
+
+int bipbuf_size(const bipbuf_t* me)
+{
+    return me->size;
+}
+
+int bipbuf_used(const bipbuf_t* me)
+{
+    return (me->a_end - me->a_start) + me->b_end;
+}
+
+int bipbuf_available(const bipbuf_t* me)
+{
+    int avail = me->size - me->a_start;
+	int a_size = me->a_end - me->a_start;
+    if (avail > a_size) avail = a_size;
+    return avail;
+}
+
+void bipbuf_init(bipbuf_t* me, const unsigned int size)
+{
+	me->a_start = me->a_end = me->b_end = 0;
+	me->size = size;
+	me->b_inuse = 0;
+}
+
+void bipbuf_resize(bipbuf_t* me, const unsigned int size)
+{
+	if (size == me->size) return;
+	if ((size > me->size && 1 == me->b_inuse) || 
+		(size < me->size && size < me->a_end))
+	{
+		const int a_size = me->a_end - me->a_start;
+		const unsigned int a_new_start = 1 == me->b_inuse ? size - a_size : 0;
+		memmove(me->data + a_new_start, me->data + me->a_start, a_size);
+		me->a_start = a_new_start;
+		me->a_end = a_new_start + a_size;
+	}
+	me->size = size;
+}
+
+bipbuf_t *bipbuf_new(const unsigned int size)
+{
+    bipbuf_t *me = malloc(bipbuf_sizeof(size));
+    if (!me)
+        return NULL;
+    bipbuf_init(me, size);
+    return me;
+}
+
+void bipbuf_free(bipbuf_t* me)
+{
+    free(me);
+}
+
+int bipbuf_is_empty(const bipbuf_t* me)
+{
+    return me->a_start == me->a_end;
+}
+
+/* find out if we should turn on region B
+ * ie. is the distance from A to buffer's end less than B to A? */
+static void __check_for_switch_to_b(bipbuf_t* me)
+{
+    if (me->size - me->a_end < me->a_start - me->b_end)
+        me->b_inuse = 1;
+}
+
+int bipbuf_offer(bipbuf_t* me, const unsigned char *data, const int size)
+{
+    /* not enough space */
+    if (bipbuf_unused(me) < size)
+        return 0;
+
+    if (1 == me->b_inuse)
+    {
+        memcpy(me->data + me->b_end, data, size);
+        me->b_end += size;
+    }
+    else
+    {
+        memcpy(me->data + me->a_end, data, size);
+        me->a_end += size;
+    }
+
+    __check_for_switch_to_b(me);
+    return size;
+}
+
+unsigned char *bipbuf_peek(const bipbuf_t* me, const unsigned int size)
+{
+    /* make sure we can actually peek at this data */
+    if (me->size < me->a_start + size)
+        return NULL;
+
+    if (bipbuf_is_empty(me))
+        return NULL;
+
+    return (unsigned char*)me->data + me->a_start;
+}
+
+unsigned char *bipbuf_poll(bipbuf_t* me, const unsigned int size)
+{
+    if (bipbuf_is_empty(me))
+        return NULL;
+
+    /* make sure we can actually poll this data */
+    if (me->size < me->a_start + size)
+        return NULL;
+
+    void *end = me->data + me->a_start;
+    me->a_start += size;
+
+    /* we seem to be empty.. */
+    if (me->a_start == me->a_end)
+    {
+        /* replace a with region b */
+        if (1 == me->b_inuse)
+        {
+            me->a_start = 0;
+            me->a_end = me->b_end;
+            me->b_end = me->b_inuse = 0;
+        }
+        else
+            /* safely move cursor back to the start because we are empty */
+            me->a_start = me->a_end = 0;
+    }
+
+    __check_for_switch_to_b(me);
+    return end;
+}

--- a/loom/common/utils/bipbuffer.c
+++ b/loom/common/utils/bipbuffer.c
@@ -131,6 +131,7 @@ unsigned char *bipbuf_peek(const bipbuf_t* me, const unsigned int size)
 
 unsigned char *bipbuf_poll(bipbuf_t* me, const unsigned int size)
 {
+    void *end;
     if (bipbuf_is_empty(me))
         return NULL;
 
@@ -138,7 +139,7 @@ unsigned char *bipbuf_poll(bipbuf_t* me, const unsigned int size)
     if (me->size < me->a_start + size)
         return NULL;
 
-    void *end = me->data + me->a_start;
+    end = me->data + me->a_start;
     me->a_start += size;
 
     /* we seem to be empty.. */

--- a/loom/common/utils/bipbuffer.h
+++ b/loom/common/utils/bipbuffer.h
@@ -1,0 +1,95 @@
+#ifndef BIPBUFFER_H
+#define BIPBUFFER_H
+
+typedef struct
+{
+    unsigned long int size;
+
+    /* region A */
+    unsigned int a_start, a_end;
+
+    /* region B */
+    unsigned int b_end;
+
+    /* is B inuse? */
+    int b_inuse;
+
+    unsigned char data[];
+} bipbuf_t;
+
+/**
+ * Create a new bip buffer.
+ *
+ * malloc()s space
+ *
+ * @param[in] size The size of the buffer */
+bipbuf_t *bipbuf_new(const unsigned int size);
+
+/**
+ * Initialise a bip buffer. Use memory provided by user.
+ *
+ * No malloc()s are performed.
+ *
+ * @param[in] size The size of the array */
+void bipbuf_init(bipbuf_t* me, const unsigned int size);
+
+/**
+ * Resize the bip buffer.
+ *
+ * If the provided new size is bigger, data is shifted around as to provide
+ * as much usable free space as possible. Call after allocating more space.
+ *
+ * If the provided new size is smaller, data is shifted to fit inside. If the
+ * new size is smaller than the number of bytes in use the behavior
+ * is undefined. Call before shrinking available space.
+ *
+ * No malloc()s are performed.
+ *
+ */
+void bipbuf_resize(bipbuf_t* me, const unsigned int size);
+
+/**
+ * Free the bip buffer */
+void bipbuf_free(bipbuf_t *me);
+
+/**
+ * @param[in] data The data to be offered to the buffer
+ * @param[in] size The size of the data to be offered
+ * @return number of bytes offered */
+int bipbuf_offer(bipbuf_t *me, const unsigned char *data, const int size);
+
+/**
+ * Look at data. Don't move cursor
+ *
+ * @param[in] len The length of the data to be peeked
+ * @return data on success, NULL if we can't peek at this much data */
+unsigned char *bipbuf_peek(const bipbuf_t* me, const unsigned int len);
+
+/**
+ * Get pointer to data to read. Move the cursor on.
+ *
+ * @param[in] len The length of the data to be polled
+ * @return pointer to data, NULL if we can't poll this much data */
+unsigned char *bipbuf_poll(bipbuf_t* me, const unsigned int size);
+
+/**
+ * @return the size of the bipbuffer */
+int bipbuf_size(const bipbuf_t* me);
+
+/**
+ * @return 1 if buffer is empty; 0 otherwise */
+int bipbuf_is_empty(const bipbuf_t* me);
+
+/**
+ * @return how much space we have assigned */
+int bipbuf_used(const bipbuf_t* cb);
+
+/**
+ * @return bytes of unused space */
+int bipbuf_unused(const bipbuf_t* me);
+
+/**
+* @return max bytes available for peek/poll */
+int bipbuf_available(const bipbuf_t* me);
+
+#endif /* BIPBUFFER_H */

--- a/loom/common/utils/bipbuffer.txt
+++ b/loom/common/utils/bipbuffer.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2011, Willem-Hendrik Thiart
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * The names of its contributors may not be used to endorse or promote
+      products derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL WILLEM-HENDRIK THIART BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/loom/common/utils/json.h
+++ b/loom/common/utils/json.h
@@ -23,15 +23,14 @@
 
 #include "jansson.h"
 #include "loom/common/utils/utString.h"
+#include "loom/common/utils/utByteArray.h"
 
 class JSON {
     // The native _json object
     json_t *_json;
+    utString _errorMsg;
 
-    // JSON error codes
-    json_error_t _error;
-    utString     _errorMsg;
-    bool         _root;
+    JSON(json_t* from);
 
 public:
 
@@ -43,6 +42,7 @@ public:
     bool initArray();
     bool loadString(const char *json);
     const char *serialize();
+    bool serializeToBuffer(utByteArray* bytes);
     const char *getError();
     int getJSONType();
     int getObjectJSONType(const char *key);
@@ -61,14 +61,18 @@ public:
     void setString(const char *key, const char *value);
 
     // Objects
-    JSON *getObject(const char *key);
+    JSON getObject(const char *key);
+    // Get JSON object allocated on the heap, lmDelete when you are done!
+    JSON* getObjectNew(const char *key);
     void setObject(const char *key, JSON *object);
     bool isObject();
     const char *getObjectFirstKey();
     const char *getObjectNextKey(const char *key);
 
     // Arrays
-    JSON *getArray(const char *key);
+    JSON getArray(const char *key);
+    // Get JSON array allocated on the heap, lmDelete when you are done!
+    JSON* getArrayNew(const char *key);
     void setArray(const char *key, JSON *object);
     bool isArray();
     int getArrayCount();
@@ -82,9 +86,13 @@ public:
     void setArrayNumber(int index, double value);
     const char *getArrayString(int index);
     void setArrayString(int index, const char *value);
-    JSON *getArrayObject(int index);
+    JSON getArrayObject(int index);
+    // Get JSON array object allocated on the heap, lmDelete when you are done!
+    JSON* getArrayObjectNew(int index);
     void setArrayObject(int index, JSON *value);
-    JSON *getArrayArray(int index);
+    JSON getArrayArray(int index);
+    // Get JSON array array allocated on the heap, lmDelete when you are done!
+    JSON* getArrayArrayNew(int index);
     void setArrayArray(int index, JSON *value);
     void expandArray(int desiredLength);
 };

--- a/loom/common/utils/utByteArray.cpp
+++ b/loom/common/utils/utByteArray.cpp
@@ -29,10 +29,10 @@
 // can be enlarged by to avoid resizing the buffer too much.
 #define BUFFER_DELTA_MAX 10*1024*1024
 
-void utByteArray::clear()
+void utByteArray::clear(bool useCache)
 {
     _position = 0;
-    _data.resize(0);
+    _data.clear(useCache);
 }
 
 

--- a/loom/common/utils/utByteArray.h
+++ b/loom/common/utils/utByteArray.h
@@ -45,12 +45,8 @@ protected:
     template<typename T>
     T readValue()
     {
-        if (_position > _data.size() - sizeof(T))
-        {
-            //lmAssert(0, "ByteArray out of data on read of size %u", sizeof(T));
-            assert(0);
-        }
-
+        lmAssert(_position <= _data.size() - sizeof(T), "ByteArray out of data on read of size %u", sizeof(T));
+        
         T *ptr  = (T *)&_data[_position];
         T value;
 
@@ -143,7 +139,7 @@ public:
         _position = 0;
     }
 
-    void clear();
+    void clear(bool useCache = false);
 
     void setPosition(unsigned int value)
     {
@@ -251,6 +247,16 @@ public:
         writeValue<unsigned int>(value);
     }
 
+    unsigned long long readUnsignedInt64()
+    {
+        return readValue<unsigned long long>();
+    }
+
+    void writeUnsignedInt64(UTuint64 value)
+    {
+        writeValue<unsigned long long>(value);
+    }
+
     void writeString(const char *value)
     {
         if (!value)
@@ -275,7 +281,7 @@ public:
         }
 
         char *ptr = (char *)&_data[_position];
-        memcpy(ptr, value, length);
+        memcpyUnaligned(ptr, value, length);
 
         _position += length;
     }
@@ -294,7 +300,8 @@ public:
 
         lmAssert(_position + length <= _data.size(), "Insufficient data available for length of %d (use readStringBytes if you don't have a 32-bit integer length header)", length);
 
-        svalue.fromBytes(&_data[_position], length);
+        svalue.alloc(length);
+        memcpyUnaligned((void*)svalue.c_str(), &_data[_position], length);
         
         _position += length;
 
@@ -361,7 +368,7 @@ public:
         }
 
         char *ptr = (char *)&_data[_position];
-        memcpy(ptr, value, length);
+        memcpyUnaligned(ptr, value, length);
 
         _position += length;
     }

--- a/loom/common/utils/utString.cpp
+++ b/loom/common/utils/utString.cpp
@@ -99,6 +99,14 @@ void utString::replace(char from, char to)
     }
 }
 
+void utString::alloc(int len)
+{
+    // Free old value if any.
+    clear();
+
+    // Allocate len+1 zero bytes
+    p = (char*)lmCalloc(NULL, 1, len + 1);
+}
 
 void utString::fromBytes(const void *bytes, int len)
 {

--- a/loom/common/utils/utString.h
+++ b/loom/common/utils/utString.h
@@ -50,6 +50,7 @@
 //* Copyright (C) Christian Stigen Larsen, 2007
 //* Placed in the Public Domain by the author.
 class utString {
+protected:
     char *p;
 public:
     typedef size_t   size_type;
@@ -88,6 +89,9 @@ public:
     char at(const size_type n) const;
     utString& erase(size_type pos, size_type len);
 
+    // Allocate enough space for a string of `length` length not including
+    // the NULL terminator.
+    void alloc(int length);
     // Set this string's value from raw bytes, NULL terminating them.
     void fromBytes(const void *bytes, int length);
     void assign(const char* bytes, int length);

--- a/loom/common/utils/utTypes.h
+++ b/loom/common/utils/utTypes.h
@@ -767,9 +767,11 @@ public:
     {
         if (nr < m_size)
         {
-            for (UTsize i = m_size; i < nr; i++)
-            {
-                m_data[i].~T();
+            if (!ArrayAlloc<T>::fundamental) {
+                for (UTsize i = m_size; i < nr; i++)
+                {
+                    m_data[i].~T();
+                }
             }
         }
         else
@@ -786,9 +788,11 @@ public:
     {
         if (nr < m_size)
         {
-            for (UTsize i = m_size; i < nr; i++)
-            {
-                m_data[i].~T();
+            if (!ArrayAlloc<T>::fundamental) {
+                for (UTsize i = m_size; i < nr; i++)
+                {
+                    m_data[i].~T();
+                }
             }
         }
         else
@@ -1199,6 +1203,24 @@ public:
 
     UT_INLINE bool operator==(const utIntHashKey& v) const { return hash() == v.hash(); }
     UT_INLINE bool operator!=(const utIntHashKey& v) const { return hash() != v.hash(); }
+    UT_INLINE bool operator==(const UThash& v) const { return hash() == v; }
+    UT_INLINE bool operator!=(const UThash& v) const { return hash() != v; }
+};
+
+class utUInt64HashKey
+{
+protected:
+    UTuint64 m_key;
+public:
+    utUInt64HashKey() : m_key(0) {}
+    utUInt64HashKey(UTuint64 k) : m_key(k) {}
+    utUInt64HashKey(const utUInt64HashKey& k) : m_key(k.m_key) {}
+
+    UT_INLINE UTuint64 key(void)  const { return m_key; }
+    UT_INLINE UThash hash(void) const { return static_cast<UThash>(m_key * 1099511628211L); }
+
+    UT_INLINE bool operator==(const utUInt64HashKey& v) const { return hash() == v.hash() && key() == v.key(); }
+    UT_INLINE bool operator!=(const utUInt64HashKey& v) const { return hash() != v.hash() || key() != v.key(); }
     UT_INLINE bool operator==(const UThash& v) const { return hash() == v; }
     UT_INLINE bool operator!=(const UThash& v) const { return hash() != v; }
 };

--- a/loom/common/utils/uthash.h
+++ b/loom/common/utils/uthash.h
@@ -1,0 +1,1074 @@
+/*
+Copyright (c) 2003-2016, Troy D. Hanson     http://troydhanson.github.com/uthash/
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTHASH_H
+#define UTHASH_H
+
+#define UTHASH_VERSION 2.0.1
+
+#include <string.h>   /* memcmp,strlen */
+#include <stddef.h>   /* ptrdiff_t */
+#include <stdlib.h>   /* exit() */
+
+/* These macros use decltype or the earlier __typeof GNU extension.
+   As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+   when compiling c++ source) this code uses whatever method is needed
+   or, for VS2008 where neither is available, uses casting workarounds. */
+#if defined(_MSC_VER)   /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#define DECLTYPE(x) (decltype(x))
+#else                   /* VS2008 or older (or VS2010 in C mode) */
+#define NO_DECLTYPE
+#define DECLTYPE(x)
+#endif
+#elif defined(__BORLANDC__) || defined(__LCC__) || defined(__WATCOMC__)
+#define NO_DECLTYPE
+#define DECLTYPE(x)
+#else                   /* GNU, Sun and other compilers */
+#define DECLTYPE(x) (__typeof(x))
+#endif
+
+#ifdef NO_DECLTYPE
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  char **_da_dst = (char**)(&(dst));                                             \
+  *_da_dst = (char*)(src);                                                       \
+} while (0)
+#else
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  (dst) = DECLTYPE(dst)(src);                                                    \
+} while (0)
+#endif
+
+/* a number of the hash function use uint32_t which isn't defined on Pre VS2010 */
+#if defined(_WIN32)
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#include <stdint.h>
+#elif defined(__WATCOMC__) || defined(__MINGW32__) || defined(__CYGWIN__)
+#include <stdint.h>
+#else
+typedef unsigned int uint32_t;
+typedef unsigned char uint8_t;
+#endif
+#elif defined(__GNUC__) && !defined(__VXWORKS__)
+#include <stdint.h>
+#else
+typedef unsigned int uint32_t;
+typedef unsigned char uint8_t;
+#endif
+
+#ifndef uthash_fatal
+#define uthash_fatal(msg) exit(-1)        /* fatal error (out of memory,etc) */
+#endif
+#ifndef uthash_malloc
+#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#endif
+#ifndef uthash_free
+#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+#endif
+#ifndef uthash_strlen
+#define uthash_strlen(s) strlen(s)
+#endif
+#ifndef uthash_memcmp
+#define uthash_memcmp(a,b,n) memcmp(a,b,n)
+#endif
+
+#ifndef uthash_noexpand_fyi
+#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#endif
+#ifndef uthash_expand_fyi
+#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+#endif
+
+/* initial number of buckets */
+#define HASH_INITIAL_NUM_BUCKETS 32U     /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS_LOG2 5U /* lg2 of initial number of buckets */
+#define HASH_BKT_CAPACITY_THRESH 10U     /* expand when bucket count reaches */
+
+/* calculate the element whose hash handle address is hhp */
+#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+/* calculate the hash handle from element address elp */
+#define HH_FROM_ELMT(tbl,elp) ((UT_hash_handle *)(((char*)(elp)) + ((tbl)->hho)))
+
+#define HASH_VALUE(keyptr,keylen,hashv)                                          \
+do {                                                                             \
+  HASH_FCN(keyptr, keylen, hashv);                                               \
+} while (0)
+
+#define HASH_FIND_BYHASHVALUE(hh,head,keyptr,keylen,hashval,out)                 \
+do {                                                                             \
+  (out) = NULL;                                                                  \
+  if (head) {                                                                    \
+    unsigned _hf_bkt;                                                            \
+    HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _hf_bkt);                  \
+    if (HASH_BLOOM_TEST((head)->hh.tbl, hashval) != 0) {                         \
+      HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ], keyptr, keylen, hashval, out); \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
+do {                                                                             \
+  unsigned _hf_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen, _hf_hashv);                                         \
+  HASH_FIND_BYHASHVALUE(hh, head, keyptr, keylen, _hf_hashv, out);               \
+} while (0)
+
+#ifdef HASH_BLOOM
+#define HASH_BLOOM_BITLEN (1UL << HASH_BLOOM)
+#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8UL) + (((HASH_BLOOM_BITLEN%8UL)!=0UL) ? 1UL : 0UL)
+#define HASH_BLOOM_MAKE(tbl)                                                     \
+do {                                                                             \
+  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
+  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
+  if (!((tbl)->bloom_bv))  { uthash_fatal( "out of memory"); }                   \
+  memset((tbl)->bloom_bv, 0, HASH_BLOOM_BYTELEN);                                \
+  (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                       \
+} while (0)
+
+#define HASH_BLOOM_FREE(tbl)                                                     \
+do {                                                                             \
+  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
+} while (0)
+
+#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8U] |= (1U << ((idx)%8U)))
+#define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8U] & (1U << ((idx)%8U)))
+
+#define HASH_BLOOM_ADD(tbl,hashv)                                                \
+  HASH_BLOOM_BITSET((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1U)))
+
+#define HASH_BLOOM_TEST(tbl,hashv)                                               \
+  HASH_BLOOM_BITTEST((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1U)))
+
+#else
+#define HASH_BLOOM_MAKE(tbl)
+#define HASH_BLOOM_FREE(tbl)
+#define HASH_BLOOM_ADD(tbl,hashv)
+#define HASH_BLOOM_TEST(tbl,hashv) (1)
+#define HASH_BLOOM_BYTELEN 0U
+#endif
+
+#define HASH_MAKE_TABLE(hh,head)                                                 \
+do {                                                                             \
+  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(                                \
+                  sizeof(UT_hash_table));                                        \
+  if (!((head)->hh.tbl))  { uthash_fatal( "out of memory"); }                    \
+  memset((head)->hh.tbl, 0, sizeof(UT_hash_table));                              \
+  (head)->hh.tbl->tail = &((head)->hh);                                          \
+  (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                        \
+  (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;              \
+  (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                    \
+  (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                      \
+          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
+  if (! (head)->hh.tbl->buckets) { uthash_fatal( "out of memory"); }             \
+  memset((head)->hh.tbl->buckets, 0,                                             \
+          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
+  HASH_BLOOM_MAKE((head)->hh.tbl);                                               \
+  (head)->hh.tbl->signature = HASH_SIGNATURE;                                    \
+} while (0)
+
+#define HASH_REPLACE_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,replaced,cmpfcn) \
+do {                                                                             \
+  (replaced) = NULL;                                                             \
+  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
+  if (replaced) {                                                                \
+     HASH_DELETE(hh, head, replaced);                                            \
+  }                                                                              \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn); \
+} while (0)
+
+#define HASH_REPLACE_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add,replaced) \
+do {                                                                             \
+  (replaced) = NULL;                                                             \
+  HASH_FIND_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, replaced); \
+  if (replaced) {                                                                \
+     HASH_DELETE(hh, head, replaced);                                            \
+  }                                                                              \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add); \
+} while (0)
+
+#define HASH_REPLACE(hh,head,fieldname,keylen_in,add,replaced)                   \
+do {                                                                             \
+  unsigned _hr_hashv;                                                            \
+  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
+  HASH_REPLACE_BYHASHVALUE(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced); \
+} while (0)
+
+#define HASH_REPLACE_INORDER(hh,head,fieldname,keylen_in,add,replaced,cmpfcn)    \
+do {                                                                             \
+  unsigned _hr_hashv;                                                            \
+  HASH_VALUE(&((add)->fieldname), keylen_in, _hr_hashv);                         \
+  HASH_REPLACE_BYHASHVALUE_INORDER(hh, head, fieldname, keylen_in, _hr_hashv, add, replaced, cmpfcn); \
+} while (0)
+
+#define HASH_APPEND_LIST(hh, head, add)                                          \
+do {                                                                             \
+  (add)->hh.next = NULL;                                                         \
+  (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);           \
+  (head)->hh.tbl->tail->next = (add);                                            \
+  (head)->hh.tbl->tail = &((add)->hh);                                           \
+} while (0)
+
+#define HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh,head,keyptr,keylen_in,hashval,add,cmpfcn) \
+do {                                                                             \
+  unsigned _ha_bkt;                                                              \
+  (add)->hh.hashv = (hashval);                                                   \
+  (add)->hh.key = (char*) (keyptr);                                              \
+  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
+  if (!(head)) {                                                                 \
+    (add)->hh.next = NULL;                                                       \
+    (add)->hh.prev = NULL;                                                       \
+    (head) = (add);                                                              \
+    HASH_MAKE_TABLE(hh, head);                                                   \
+  } else {                                                                       \
+    struct UT_hash_handle *_hs_iter = &(head)->hh;                               \
+    (add)->hh.tbl = (head)->hh.tbl;                                              \
+    do {                                                                         \
+      if (cmpfcn(DECLTYPE(head) ELMT_FROM_HH((head)->hh.tbl, _hs_iter), add) > 0) \
+        break;                                                                   \
+    } while ((_hs_iter = _hs_iter->next));                                       \
+    if (_hs_iter) {                                                              \
+      (add)->hh.next = _hs_iter;                                                 \
+      if (((add)->hh.prev = _hs_iter->prev)) {                                   \
+        HH_FROM_ELMT((head)->hh.tbl, _hs_iter->prev)->next = (add);              \
+      } else {                                                                   \
+        (head) = (add);                                                          \
+      }                                                                          \
+      _hs_iter->prev = (add);                                                    \
+    } else {                                                                     \
+      HASH_APPEND_LIST(hh, head, add);                                           \
+    }                                                                            \
+  }                                                                              \
+  (head)->hh.tbl->num_items++;                                                   \
+  HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                    \
+  HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], &(add)->hh);                 \
+  HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                       \
+  HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                    \
+  HASH_FSCK(hh, head);                                                           \
+} while (0)
+
+#define HASH_ADD_KEYPTR_INORDER(hh,head,keyptr,keylen_in,add,cmpfcn)             \
+do {                                                                             \
+  unsigned _hs_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen_in, _hs_hashv);                                      \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, keyptr, keylen_in, _hs_hashv, add, cmpfcn); \
+} while (0)
+
+#define HASH_ADD_BYHASHVALUE_INORDER(hh,head,fieldname,keylen_in,hashval,add,cmpfcn) \
+  HASH_ADD_KEYPTR_BYHASHVALUE_INORDER(hh, head, &((add)->fieldname), keylen_in, hashval, add, cmpfcn)
+
+#define HASH_ADD_INORDER(hh,head,fieldname,keylen_in,add,cmpfcn)                 \
+  HASH_ADD_KEYPTR_INORDER(hh, head, &((add)->fieldname), keylen_in, add, cmpfcn)
+
+#define HASH_ADD_KEYPTR_BYHASHVALUE(hh,head,keyptr,keylen_in,hashval,add)        \
+do {                                                                             \
+  unsigned _ha_bkt;                                                              \
+  (add)->hh.hashv = (hashval);                                                   \
+  (add)->hh.key = (char*) (keyptr);                                              \
+  (add)->hh.keylen = (unsigned) (keylen_in);                                     \
+  if (!(head)) {                                                                 \
+    (add)->hh.next = NULL;                                                       \
+    (add)->hh.prev = NULL;                                                       \
+    (head) = (add);                                                              \
+    HASH_MAKE_TABLE(hh, head);                                                   \
+  } else {                                                                       \
+    (add)->hh.tbl = (head)->hh.tbl;                                              \
+    HASH_APPEND_LIST(hh, head, add);                                             \
+  }                                                                              \
+  (head)->hh.tbl->num_items++;                                                   \
+  HASH_TO_BKT(hashval, (head)->hh.tbl->num_buckets, _ha_bkt);                    \
+  HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt], &(add)->hh);                 \
+  HASH_BLOOM_ADD((head)->hh.tbl, hashval);                                       \
+  HASH_EMIT_KEY(hh, head, keyptr, keylen_in);                                    \
+  HASH_FSCK(hh, head);                                                           \
+} while (0)
+
+#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
+do {                                                                             \
+  unsigned _ha_hashv;                                                            \
+  HASH_VALUE(keyptr, keylen_in, _ha_hashv);                                      \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, keyptr, keylen_in, _ha_hashv, add);      \
+} while (0)
+
+#define HASH_ADD_BYHASHVALUE(hh,head,fieldname,keylen_in,hashval,add)            \
+  HASH_ADD_KEYPTR_BYHASHVALUE(hh, head, &((add)->fieldname), keylen_in, hashval, add)
+
+#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
+  HASH_ADD_KEYPTR(hh, head, &((add)->fieldname), keylen_in, add)
+
+#define HASH_TO_BKT(hashv,num_bkts,bkt)                                          \
+do {                                                                             \
+  bkt = ((hashv) & ((num_bkts) - 1U));                                           \
+} while (0)
+
+/* delete "delptr" from the hash table.
+ * "the usual" patch-up process for the app-order doubly-linked-list.
+ * The use of _hd_hh_del below deserves special explanation.
+ * These used to be expressed using (delptr) but that led to a bug
+ * if someone used the same symbol for the head and deletee, like
+ *  HASH_DELETE(hh,users,users);
+ * We want that to work, but by changing the head (users) below
+ * we were forfeiting our ability to further refer to the deletee (users)
+ * in the patch-up process. Solution: use scratch space to
+ * copy the deletee pointer, then the latter references are via that
+ * scratch pointer rather than through the repointed (users) symbol.
+ */
+#define HASH_DELETE(hh,head,delptr)                                              \
+do {                                                                             \
+    struct UT_hash_handle *_hd_hh_del;                                           \
+    if ( ((delptr)->hh.prev == NULL) && ((delptr)->hh.next == NULL) )  {         \
+        uthash_free((head)->hh.tbl->buckets,                                     \
+                    (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
+        HASH_BLOOM_FREE((head)->hh.tbl);                                         \
+        uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                      \
+        head = NULL;                                                             \
+    } else {                                                                     \
+        unsigned _hd_bkt;                                                        \
+        _hd_hh_del = &((delptr)->hh);                                            \
+        if ((delptr) == ELMT_FROM_HH((head)->hh.tbl,(head)->hh.tbl->tail)) {     \
+            (head)->hh.tbl->tail =                                               \
+                (UT_hash_handle*)((ptrdiff_t)((delptr)->hh.prev) +               \
+                (head)->hh.tbl->hho);                                            \
+        }                                                                        \
+        if ((delptr)->hh.prev != NULL) {                                         \
+            ((UT_hash_handle*)((ptrdiff_t)((delptr)->hh.prev) +                  \
+                    (head)->hh.tbl->hho))->next = (delptr)->hh.next;             \
+        } else {                                                                 \
+            DECLTYPE_ASSIGN(head,(delptr)->hh.next);                             \
+        }                                                                        \
+        if (_hd_hh_del->next != NULL) {                                          \
+            ((UT_hash_handle*)((ptrdiff_t)_hd_hh_del->next +                     \
+                    (head)->hh.tbl->hho))->prev =                                \
+                    _hd_hh_del->prev;                                            \
+        }                                                                        \
+        HASH_TO_BKT( _hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);   \
+        HASH_DEL_IN_BKT(hh,(head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);        \
+        (head)->hh.tbl->num_items--;                                             \
+    }                                                                            \
+    HASH_FSCK(hh,head);                                                          \
+} while (0)
+
+
+/* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
+#define HASH_FIND_STR(head,findstr,out)                                          \
+    HASH_FIND(hh,head,findstr,(unsigned)uthash_strlen(findstr),out)
+#define HASH_ADD_STR(head,strfield,add)                                          \
+    HASH_ADD(hh,head,strfield[0],(unsigned)uthash_strlen(add->strfield),add)
+#define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,strfield[0],(unsigned)uthash_strlen(add->strfield),add,replaced)
+#define HASH_FIND_INT(head,findint,out)                                          \
+    HASH_FIND(hh,head,findint,sizeof(int),out)
+#define HASH_ADD_INT(head,intfield,add)                                          \
+    HASH_ADD(hh,head,intfield,sizeof(int),add)
+#define HASH_REPLACE_INT(head,intfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,intfield,sizeof(int),add,replaced)
+#define HASH_FIND_PTR(head,findptr,out)                                          \
+    HASH_FIND(hh,head,findptr,sizeof(void *),out)
+#define HASH_ADD_PTR(head,ptrfield,add)                                          \
+    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
+#define HASH_REPLACE_PTR(head,ptrfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,ptrfield,sizeof(void *),add,replaced)
+#define HASH_DEL(head,delptr)                                                    \
+    HASH_DELETE(hh,head,delptr)
+
+/* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
+ * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
+ */
+#ifdef HASH_DEBUG
+#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
+#define HASH_FSCK(hh,head)                                                       \
+do {                                                                             \
+    struct UT_hash_handle *_thh;                                                 \
+    if (head) {                                                                  \
+        unsigned _bkt_i;                                                         \
+        unsigned _count;                                                         \
+        char *_prev;                                                             \
+        _count = 0;                                                              \
+        for( _bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; _bkt_i++) {       \
+            unsigned _bkt_count = 0;                                             \
+            _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                      \
+            _prev = NULL;                                                        \
+            while (_thh) {                                                       \
+               if (_prev != (char*)(_thh->hh_prev)) {                            \
+                   HASH_OOPS("invalid hh_prev %p, actual %p\n",                  \
+                    _thh->hh_prev, _prev );                                      \
+               }                                                                 \
+               _bkt_count++;                                                     \
+               _prev = (char*)(_thh);                                            \
+               _thh = _thh->hh_next;                                             \
+            }                                                                    \
+            _count += _bkt_count;                                                \
+            if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {          \
+               HASH_OOPS("invalid bucket count %u, actual %u\n",                 \
+                (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);              \
+            }                                                                    \
+        }                                                                        \
+        if (_count != (head)->hh.tbl->num_items) {                               \
+            HASH_OOPS("invalid hh item count %u, actual %u\n",                   \
+                (head)->hh.tbl->num_items, _count );                             \
+        }                                                                        \
+        /* traverse hh in app order; check next/prev integrity, count */         \
+        _count = 0;                                                              \
+        _prev = NULL;                                                            \
+        _thh =  &(head)->hh;                                                     \
+        while (_thh) {                                                           \
+           _count++;                                                             \
+           if (_prev !=(char*)(_thh->prev)) {                                    \
+              HASH_OOPS("invalid prev %p, actual %p\n",                          \
+                    _thh->prev, _prev );                                         \
+           }                                                                     \
+           _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                    \
+           _thh = ( _thh->next ?  (UT_hash_handle*)((char*)(_thh->next) +        \
+                                  (head)->hh.tbl->hho) : NULL );                 \
+        }                                                                        \
+        if (_count != (head)->hh.tbl->num_items) {                               \
+            HASH_OOPS("invalid app item count %u, actual %u\n",                  \
+                (head)->hh.tbl->num_items, _count );                             \
+        }                                                                        \
+    }                                                                            \
+} while (0)
+#else
+#define HASH_FSCK(hh,head)
+#endif
+
+/* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to
+ * the descriptor to which this macro is defined for tuning the hash function.
+ * The app can #include <unistd.h> to get the prototype for write(2). */
+#ifdef HASH_EMIT_KEYS
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
+do {                                                                             \
+    unsigned _klen = fieldlen;                                                   \
+    write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                \
+    write(HASH_EMIT_KEYS, keyptr, (unsigned long)fieldlen);                      \
+} while (0)
+#else
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
+#endif
+
+/* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
+#ifdef HASH_FUNCTION
+#define HASH_FCN HASH_FUNCTION
+#else
+#define HASH_FCN HASH_JEN
+#endif
+
+/* The Bernstein hash function, used in Perl prior to v5.6. Note (x<<5+x)=x*33. */
+#define HASH_BER(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _hb_keylen=(unsigned)keylen;                                          \
+  const unsigned char *_hb_key=(const unsigned char*)(key);                      \
+  (hashv) = 0;                                                                   \
+  while (_hb_keylen-- != 0U) {                                                   \
+      (hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++;                         \
+  }                                                                              \
+} while (0)
+
+
+/* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at
+ * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx */
+#define HASH_SAX(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _sx_i;                                                                \
+  const unsigned char *_hs_key=(const unsigned char*)(key);                      \
+  hashv = 0;                                                                     \
+  for(_sx_i=0; _sx_i < keylen; _sx_i++) {                                        \
+      hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                     \
+  }                                                                              \
+} while (0)
+/* FNV-1a variation */
+#define HASH_FNV(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _fn_i;                                                                \
+  const unsigned char *_hf_key=(const unsigned char*)(key);                      \
+  hashv = 2166136261U;                                                           \
+  for(_fn_i=0; _fn_i < keylen; _fn_i++) {                                        \
+      hashv = hashv ^ _hf_key[_fn_i];                                            \
+      hashv = hashv * 16777619U;                                                 \
+  }                                                                              \
+} while (0)
+
+#define HASH_OAT(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _ho_i;                                                                \
+  const unsigned char *_ho_key=(const unsigned char*)(key);                      \
+  hashv = 0;                                                                     \
+  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
+      hashv += _ho_key[_ho_i];                                                   \
+      hashv += (hashv << 10);                                                    \
+      hashv ^= (hashv >> 6);                                                     \
+  }                                                                              \
+  hashv += (hashv << 3);                                                         \
+  hashv ^= (hashv >> 11);                                                        \
+  hashv += (hashv << 15);                                                        \
+} while (0)
+
+#define HASH_JEN_MIX(a,b,c)                                                      \
+do {                                                                             \
+  a -= b; a -= c; a ^= ( c >> 13 );                                              \
+  b -= c; b -= a; b ^= ( a << 8 );                                               \
+  c -= a; c -= b; c ^= ( b >> 13 );                                              \
+  a -= b; a -= c; a ^= ( c >> 12 );                                              \
+  b -= c; b -= a; b ^= ( a << 16 );                                              \
+  c -= a; c -= b; c ^= ( b >> 5 );                                               \
+  a -= b; a -= c; a ^= ( c >> 3 );                                               \
+  b -= c; b -= a; b ^= ( a << 10 );                                              \
+  c -= a; c -= b; c ^= ( b >> 15 );                                              \
+} while (0)
+
+#define HASH_JEN(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned _hj_i,_hj_j,_hj_k;                                                    \
+  unsigned const char *_hj_key=(unsigned const char*)(key);                      \
+  hashv = 0xfeedbeefu;                                                           \
+  _hj_i = _hj_j = 0x9e3779b9u;                                                   \
+  _hj_k = (unsigned)(keylen);                                                    \
+  while (_hj_k >= 12U) {                                                         \
+    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
+        + ( (unsigned)_hj_key[2] << 16 )                                         \
+        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
+    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
+        + ( (unsigned)_hj_key[6] << 16 )                                         \
+        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
+    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
+        + ( (unsigned)_hj_key[10] << 16 )                                        \
+        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
+                                                                                 \
+     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
+                                                                                 \
+     _hj_key += 12;                                                              \
+     _hj_k -= 12U;                                                               \
+  }                                                                              \
+  hashv += (unsigned)(keylen);                                                   \
+  switch ( _hj_k ) {                                                             \
+     case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); /* FALLTHROUGH */        \
+     case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  /* FALLTHROUGH */        \
+     case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   /* FALLTHROUGH */        \
+     case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  /* FALLTHROUGH */        \
+     case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  /* FALLTHROUGH */        \
+     case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   /* FALLTHROUGH */        \
+     case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */        \
+     case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */        \
+     case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */        \
+     case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */        \
+     case 1:  _hj_i += _hj_key[0];                                               \
+  }                                                                              \
+  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
+} while (0)
+
+/* The Paul Hsieh hash function */
+#undef get16bits
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
+  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
+#define get16bits(d) (*((const uint16_t *) (d)))
+#endif
+
+#if !defined (get16bits)
+#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
+                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#endif
+#define HASH_SFH(key,keylen,hashv)                                               \
+do {                                                                             \
+  unsigned const char *_sfh_key=(unsigned const char*)(key);                     \
+  uint32_t _sfh_tmp, _sfh_len = (uint32_t)keylen;                                \
+                                                                                 \
+  unsigned _sfh_rem = _sfh_len & 3U;                                             \
+  _sfh_len >>= 2;                                                                \
+  hashv = 0xcafebabeu;                                                           \
+                                                                                 \
+  /* Main loop */                                                                \
+  for (;_sfh_len > 0U; _sfh_len--) {                                             \
+    hashv    += get16bits (_sfh_key);                                            \
+    _sfh_tmp  = ((uint32_t)(get16bits (_sfh_key+2)) << 11) ^ hashv;              \
+    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
+    _sfh_key += 2U*sizeof (uint16_t);                                            \
+    hashv    += hashv >> 11;                                                     \
+  }                                                                              \
+                                                                                 \
+  /* Handle end cases */                                                         \
+  switch (_sfh_rem) {                                                            \
+    case 3: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 16;                                                \
+            hashv ^= (uint32_t)(_sfh_key[sizeof (uint16_t)]) << 18;              \
+            hashv += hashv >> 11;                                                \
+            break;                                                               \
+    case 2: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 11;                                                \
+            hashv += hashv >> 17;                                                \
+            break;                                                               \
+    case 1: hashv += *_sfh_key;                                                  \
+            hashv ^= hashv << 10;                                                \
+            hashv += hashv >> 1;                                                 \
+  }                                                                              \
+                                                                                 \
+    /* Force "avalanching" of final 127 bits */                                  \
+    hashv ^= hashv << 3;                                                         \
+    hashv += hashv >> 5;                                                         \
+    hashv ^= hashv << 4;                                                         \
+    hashv += hashv >> 17;                                                        \
+    hashv ^= hashv << 25;                                                        \
+    hashv += hashv >> 6;                                                         \
+} while (0)
+
+#ifdef HASH_USING_NO_STRICT_ALIASING
+/* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned reads.
+ * For other types of CPU's (e.g. Sparc) an unaligned read causes a bus error.
+ * MurmurHash uses the faster approach only on CPU's where we know it's safe.
+ *
+ * Note the preprocessor built-in defines can be emitted using:
+ *
+ *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
+ *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
+ */
+#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
+#define MUR_GETBLOCK(p,i) p[i]
+#else /* non intel */
+#define MUR_PLUS0_ALIGNED(p) (((unsigned long)p & 3UL) == 0UL)
+#define MUR_PLUS1_ALIGNED(p) (((unsigned long)p & 3UL) == 1UL)
+#define MUR_PLUS2_ALIGNED(p) (((unsigned long)p & 3UL) == 2UL)
+#define MUR_PLUS3_ALIGNED(p) (((unsigned long)p & 3UL) == 3UL)
+#define WP(p) ((uint32_t*)((unsigned long)(p) & ~3UL))
+#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || defined(__ppc64__))
+#define MUR_THREE_ONE(p) ((((*WP(p))&0x00ffffff) << 8) | (((*(WP(p)+1))&0xff000000) >> 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p))&0x0000ffff) <<16) | (((*(WP(p)+1))&0xffff0000) >> 16))
+#define MUR_ONE_THREE(p) ((((*WP(p))&0x000000ff) <<24) | (((*(WP(p)+1))&0xffffff00) >>  8))
+#else /* assume little endian non-intel */
+#define MUR_THREE_ONE(p) ((((*WP(p))&0xffffff00) >> 8) | (((*(WP(p)+1))&0x000000ff) << 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p))&0xffff0000) >>16) | (((*(WP(p)+1))&0x0000ffff) << 16))
+#define MUR_ONE_THREE(p) ((((*WP(p))&0xff000000) >>24) | (((*(WP(p)+1))&0x00ffffff) <<  8))
+#endif
+#define MUR_GETBLOCK(p,i) (MUR_PLUS0_ALIGNED(p) ? ((p)[i]) :           \
+                            (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) : \
+                             (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) :  \
+                                                      MUR_ONE_THREE(p))))
+#endif
+#define MUR_ROTL32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define MUR_FMIX(_h) \
+do {                 \
+  _h ^= _h >> 16;    \
+  _h *= 0x85ebca6bu; \
+  _h ^= _h >> 13;    \
+  _h *= 0xc2b2ae35u; \
+  _h ^= _h >> 16;    \
+} while (0)
+
+#define HASH_MUR(key,keylen,hashv)                                     \
+do {                                                                   \
+  const uint8_t *_mur_data = (const uint8_t*)(key);                    \
+  const int _mur_nblocks = (int)(keylen) / 4;                          \
+  uint32_t _mur_h1 = 0xf88D5353u;                                      \
+  uint32_t _mur_c1 = 0xcc9e2d51u;                                      \
+  uint32_t _mur_c2 = 0x1b873593u;                                      \
+  uint32_t _mur_k1 = 0;                                                \
+  const uint8_t *_mur_tail;                                            \
+  const uint32_t *_mur_blocks = (const uint32_t*)(_mur_data+(_mur_nblocks*4)); \
+  int _mur_i;                                                          \
+  for(_mur_i = -_mur_nblocks; _mur_i!=0; _mur_i++) {                   \
+    _mur_k1 = MUR_GETBLOCK(_mur_blocks,_mur_i);                        \
+    _mur_k1 *= _mur_c1;                                                \
+    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
+    _mur_k1 *= _mur_c2;                                                \
+                                                                       \
+    _mur_h1 ^= _mur_k1;                                                \
+    _mur_h1 = MUR_ROTL32(_mur_h1,13);                                  \
+    _mur_h1 = (_mur_h1*5U) + 0xe6546b64u;                              \
+  }                                                                    \
+  _mur_tail = (const uint8_t*)(_mur_data + (_mur_nblocks*4));          \
+  _mur_k1=0;                                                           \
+  switch((keylen) & 3U) {                                              \
+    case 3: _mur_k1 ^= (uint32_t)_mur_tail[2] << 16; /* FALLTHROUGH */ \
+    case 2: _mur_k1 ^= (uint32_t)_mur_tail[1] << 8;  /* FALLTHROUGH */ \
+    case 1: _mur_k1 ^= (uint32_t)_mur_tail[0];                         \
+    _mur_k1 *= _mur_c1;                                                \
+    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
+    _mur_k1 *= _mur_c2;                                                \
+    _mur_h1 ^= _mur_k1;                                                \
+  }                                                                    \
+  _mur_h1 ^= (uint32_t)(keylen);                                       \
+  MUR_FMIX(_mur_h1);                                                   \
+  hashv = _mur_h1;                                                     \
+} while (0)
+#endif  /* HASH_USING_NO_STRICT_ALIASING */
+
+/* iterate over items in a known bucket to find desired item */
+#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,hashval,out)               \
+do {                                                                             \
+  if ((head).hh_head != NULL) {                                                  \
+    DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (head).hh_head));                     \
+  } else {                                                                       \
+    (out) = NULL;                                                                \
+  }                                                                              \
+  while ((out) != NULL) {                                                        \
+    if ((out)->hh.hashv == (hashval) && (out)->hh.keylen == (keylen_in)) {       \
+      if (uthash_memcmp((out)->hh.key, keyptr, keylen_in) == 0) {                \
+        break;                                                                   \
+      }                                                                          \
+    }                                                                            \
+    if ((out)->hh.hh_next != NULL) {                                             \
+      DECLTYPE_ASSIGN(out, ELMT_FROM_HH(tbl, (out)->hh.hh_next));                \
+    } else {                                                                     \
+      (out) = NULL;                                                              \
+    }                                                                            \
+  }                                                                              \
+} while (0)
+
+/* add an item to a bucket  */
+#define HASH_ADD_TO_BKT(head,addhh)                                              \
+do {                                                                             \
+ head.count++;                                                                   \
+ (addhh)->hh_next = head.hh_head;                                                \
+ (addhh)->hh_prev = NULL;                                                        \
+ if (head.hh_head != NULL) { (head).hh_head->hh_prev = (addhh); }                \
+ (head).hh_head=addhh;                                                           \
+ if ((head.count >= ((head.expand_mult+1U) * HASH_BKT_CAPACITY_THRESH))          \
+     && ((addhh)->tbl->noexpand != 1U)) {                                        \
+       HASH_EXPAND_BUCKETS((addhh)->tbl);                                        \
+ }                                                                               \
+} while (0)
+
+/* remove an item from a given bucket */
+#define HASH_DEL_IN_BKT(hh,head,hh_del)                                          \
+    (head).count--;                                                              \
+    if ((head).hh_head == hh_del) {                                              \
+      (head).hh_head = hh_del->hh_next;                                          \
+    }                                                                            \
+    if (hh_del->hh_prev) {                                                       \
+        hh_del->hh_prev->hh_next = hh_del->hh_next;                              \
+    }                                                                            \
+    if (hh_del->hh_next) {                                                       \
+        hh_del->hh_next->hh_prev = hh_del->hh_prev;                              \
+    }
+
+/* Bucket expansion has the effect of doubling the number of buckets
+ * and redistributing the items into the new buckets. Ideally the
+ * items will distribute more or less evenly into the new buckets
+ * (the extent to which this is true is a measure of the quality of
+ * the hash function as it applies to the key domain).
+ *
+ * With the items distributed into more buckets, the chain length
+ * (item count) in each bucket is reduced. Thus by expanding buckets
+ * the hash keeps a bound on the chain length. This bounded chain
+ * length is the essence of how a hash provides constant time lookup.
+ *
+ * The calculation of tbl->ideal_chain_maxlen below deserves some
+ * explanation. First, keep in mind that we're calculating the ideal
+ * maximum chain length based on the *new* (doubled) bucket count.
+ * In fractions this is just n/b (n=number of items,b=new num buckets).
+ * Since the ideal chain length is an integer, we want to calculate
+ * ceil(n/b). We don't depend on floating point arithmetic in this
+ * hash, so to calculate ceil(n/b) with integers we could write
+ *
+ *      ceil(n/b) = (n/b) + ((n%b)?1:0)
+ *
+ * and in fact a previous version of this hash did just that.
+ * But now we have improved things a bit by recognizing that b is
+ * always a power of two. We keep its base 2 log handy (call it lb),
+ * so now we can write this with a bit shift and logical AND:
+ *
+ *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
+ *
+ */
+#define HASH_EXPAND_BUCKETS(tbl)                                                 \
+do {                                                                             \
+    unsigned _he_bkt;                                                            \
+    unsigned _he_bkt_i;                                                          \
+    struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                 \
+    UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                \
+    _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                            \
+             2UL * tbl->num_buckets * sizeof(struct UT_hash_bucket));            \
+    if (!_he_new_buckets) { uthash_fatal( "out of memory"); }                    \
+    memset(_he_new_buckets, 0,                                                   \
+            2UL * tbl->num_buckets * sizeof(struct UT_hash_bucket));             \
+    tbl->ideal_chain_maxlen =                                                    \
+       (tbl->num_items >> (tbl->log2_num_buckets+1U)) +                          \
+       (((tbl->num_items & ((tbl->num_buckets*2U)-1U)) != 0U) ? 1U : 0U);        \
+    tbl->nonideal_items = 0;                                                     \
+    for(_he_bkt_i = 0; _he_bkt_i < tbl->num_buckets; _he_bkt_i++)                \
+    {                                                                            \
+        _he_thh = tbl->buckets[ _he_bkt_i ].hh_head;                             \
+        while (_he_thh != NULL) {                                                \
+           _he_hh_nxt = _he_thh->hh_next;                                        \
+           HASH_TO_BKT( _he_thh->hashv, tbl->num_buckets*2U, _he_bkt);           \
+           _he_newbkt = &(_he_new_buckets[ _he_bkt ]);                           \
+           if (++(_he_newbkt->count) > tbl->ideal_chain_maxlen) {                \
+             tbl->nonideal_items++;                                              \
+             _he_newbkt->expand_mult = _he_newbkt->count /                       \
+                                        tbl->ideal_chain_maxlen;                 \
+           }                                                                     \
+           _he_thh->hh_prev = NULL;                                              \
+           _he_thh->hh_next = _he_newbkt->hh_head;                               \
+           if (_he_newbkt->hh_head != NULL) { _he_newbkt->hh_head->hh_prev =     \
+                _he_thh; }                                                       \
+           _he_newbkt->hh_head = _he_thh;                                        \
+           _he_thh = _he_hh_nxt;                                                 \
+        }                                                                        \
+    }                                                                            \
+    uthash_free( tbl->buckets, tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
+    tbl->num_buckets *= 2U;                                                      \
+    tbl->log2_num_buckets++;                                                     \
+    tbl->buckets = _he_new_buckets;                                              \
+    tbl->ineff_expands = (tbl->nonideal_items > (tbl->num_items >> 1)) ?         \
+        (tbl->ineff_expands+1U) : 0U;                                            \
+    if (tbl->ineff_expands > 1U) {                                               \
+        tbl->noexpand=1;                                                         \
+        uthash_noexpand_fyi(tbl);                                                \
+    }                                                                            \
+    uthash_expand_fyi(tbl);                                                      \
+} while (0)
+
+
+/* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
+/* Note that HASH_SORT assumes the hash handle name to be hh.
+ * HASH_SRT was added to allow the hash handle name to be passed in. */
+#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
+#define HASH_SRT(hh,head,cmpfcn)                                                 \
+do {                                                                             \
+  unsigned _hs_i;                                                                \
+  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
+  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
+  if (head != NULL) {                                                            \
+      _hs_insize = 1;                                                            \
+      _hs_looping = 1;                                                           \
+      _hs_list = &((head)->hh);                                                  \
+      while (_hs_looping != 0U) {                                                \
+          _hs_p = _hs_list;                                                      \
+          _hs_list = NULL;                                                       \
+          _hs_tail = NULL;                                                       \
+          _hs_nmerges = 0;                                                       \
+          while (_hs_p != NULL) {                                                \
+              _hs_nmerges++;                                                     \
+              _hs_q = _hs_p;                                                     \
+              _hs_psize = 0;                                                     \
+              for ( _hs_i = 0; _hs_i  < _hs_insize; _hs_i++ ) {                  \
+                  _hs_psize++;                                                   \
+                  _hs_q = (UT_hash_handle*)((_hs_q->next != NULL) ?              \
+                          ((void*)((char*)(_hs_q->next) +                        \
+                          (head)->hh.tbl->hho)) : NULL);                         \
+                  if (! (_hs_q) ) { break; }                                     \
+              }                                                                  \
+              _hs_qsize = _hs_insize;                                            \
+              while ((_hs_psize > 0U) || ((_hs_qsize > 0U) && (_hs_q != NULL))) {\
+                  if (_hs_psize == 0U) {                                         \
+                      _hs_e = _hs_q;                                             \
+                      _hs_q = (UT_hash_handle*)((_hs_q->next != NULL) ?          \
+                              ((void*)((char*)(_hs_q->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_qsize--;                                               \
+                  } else if ( (_hs_qsize == 0U) || (_hs_q == NULL) ) {           \
+                      _hs_e = _hs_p;                                             \
+                      if (_hs_p != NULL){                                        \
+                        _hs_p = (UT_hash_handle*)((_hs_p->next != NULL) ?        \
+                                ((void*)((char*)(_hs_p->next) +                  \
+                                (head)->hh.tbl->hho)) : NULL);                   \
+                       }                                                         \
+                      _hs_psize--;                                               \
+                  } else if ((                                                   \
+                      cmpfcn(DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_p)), \
+                             DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_q))) \
+                             ) <= 0) {                                           \
+                      _hs_e = _hs_p;                                             \
+                      if (_hs_p != NULL){                                        \
+                        _hs_p = (UT_hash_handle*)((_hs_p->next != NULL) ?        \
+                               ((void*)((char*)(_hs_p->next) +                   \
+                               (head)->hh.tbl->hho)) : NULL);                    \
+                       }                                                         \
+                      _hs_psize--;                                               \
+                  } else {                                                       \
+                      _hs_e = _hs_q;                                             \
+                      _hs_q = (UT_hash_handle*)((_hs_q->next != NULL) ?          \
+                              ((void*)((char*)(_hs_q->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_qsize--;                                               \
+                  }                                                              \
+                  if ( _hs_tail != NULL ) {                                      \
+                      _hs_tail->next = ((_hs_e != NULL) ?                        \
+                            ELMT_FROM_HH((head)->hh.tbl,_hs_e) : NULL);          \
+                  } else {                                                       \
+                      _hs_list = _hs_e;                                          \
+                  }                                                              \
+                  if (_hs_e != NULL) {                                           \
+                  _hs_e->prev = ((_hs_tail != NULL) ?                            \
+                     ELMT_FROM_HH((head)->hh.tbl,_hs_tail) : NULL);              \
+                  }                                                              \
+                  _hs_tail = _hs_e;                                              \
+              }                                                                  \
+              _hs_p = _hs_q;                                                     \
+          }                                                                      \
+          if (_hs_tail != NULL){                                                 \
+            _hs_tail->next = NULL;                                               \
+          }                                                                      \
+          if ( _hs_nmerges <= 1U ) {                                             \
+              _hs_looping=0;                                                     \
+              (head)->hh.tbl->tail = _hs_tail;                                   \
+              DECLTYPE_ASSIGN(head,ELMT_FROM_HH((head)->hh.tbl, _hs_list));      \
+          }                                                                      \
+          _hs_insize *= 2U;                                                      \
+      }                                                                          \
+      HASH_FSCK(hh,head);                                                        \
+ }                                                                               \
+} while (0)
+
+/* This function selects items from one hash into another hash.
+ * The end result is that the selected items have dual presence
+ * in both hashes. There is no copy of the items made; rather
+ * they are added into the new hash through a secondary hash
+ * hash handle that must be present in the structure. */
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
+do {                                                                             \
+  unsigned _src_bkt, _dst_bkt;                                                   \
+  void *_last_elt=NULL, *_elt;                                                   \
+  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
+  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
+  if (src != NULL) {                                                             \
+    for(_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {     \
+      for(_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;                \
+          _src_hh != NULL;                                                       \
+          _src_hh = _src_hh->hh_next) {                                          \
+          _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                       \
+          if (cond(_elt)) {                                                      \
+            _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);               \
+            _dst_hh->key = _src_hh->key;                                         \
+            _dst_hh->keylen = _src_hh->keylen;                                   \
+            _dst_hh->hashv = _src_hh->hashv;                                     \
+            _dst_hh->prev = _last_elt;                                           \
+            _dst_hh->next = NULL;                                                \
+            if (_last_elt_hh != NULL) { _last_elt_hh->next = _elt; }             \
+            if (dst == NULL) {                                                   \
+              DECLTYPE_ASSIGN(dst,_elt);                                         \
+              HASH_MAKE_TABLE(hh_dst,dst);                                       \
+            } else {                                                             \
+              _dst_hh->tbl = (dst)->hh_dst.tbl;                                  \
+            }                                                                    \
+            HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);    \
+            HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt],_dst_hh);            \
+            (dst)->hh_dst.tbl->num_items++;                                      \
+            _last_elt = _elt;                                                    \
+            _last_elt_hh = _dst_hh;                                              \
+          }                                                                      \
+      }                                                                          \
+    }                                                                            \
+  }                                                                              \
+  HASH_FSCK(hh_dst,dst);                                                         \
+} while (0)
+
+#define HASH_CLEAR(hh,head)                                                      \
+do {                                                                             \
+  if (head != NULL) {                                                            \
+    uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
+    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
+    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+    (head)=NULL;                                                                 \
+  }                                                                              \
+} while (0)
+
+#define HASH_OVERHEAD(hh,head)                                                   \
+ ((head != NULL) ? (                                                             \
+ (size_t)(((head)->hh.tbl->num_items   * sizeof(UT_hash_handle))   +             \
+          ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket))   +             \
+           sizeof(UT_hash_table)                                   +             \
+           (HASH_BLOOM_BYTELEN))) : 0U)
+
+#ifdef NO_DECLTYPE
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for(((el)=(head)), ((*(char**)(&(tmp)))=(char*)((head!=NULL)?(head)->hh.next:NULL)); \
+  (el) != NULL; ((el)=(tmp)), ((*(char**)(&(tmp)))=(char*)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#else
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for(((el)=(head)), ((tmp)=DECLTYPE(el)((head!=NULL)?(head)->hh.next:NULL));      \
+  (el) != NULL; ((el)=(tmp)), ((tmp)=DECLTYPE(el)((tmp!=NULL)?(tmp)->hh.next:NULL)))
+#endif
+
+/* obtain a count of items in the hash */
+#define HASH_COUNT(head) HASH_CNT(hh,head)
+#define HASH_CNT(hh,head) ((head != NULL)?((head)->hh.tbl->num_items):0U)
+
+typedef struct UT_hash_bucket {
+   struct UT_hash_handle *hh_head;
+   unsigned count;
+
+   /* expand_mult is normally set to 0. In this situation, the max chain length
+    * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
+    * the bucket's chain exceeds this length, bucket expansion is triggered).
+    * However, setting expand_mult to a non-zero value delays bucket expansion
+    * (that would be triggered by additions to this particular bucket)
+    * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
+    * (The multiplier is simply expand_mult+1). The whole idea of this
+    * multiplier is to reduce bucket expansions, since they are expensive, in
+    * situations where we know that a particular bucket tends to be overused.
+    * It is better to let its chain length grow to a longer yet-still-bounded
+    * value, than to do an O(n) bucket expansion too often.
+    */
+   unsigned expand_mult;
+
+} UT_hash_bucket;
+
+/* random signature used only to find hash tables in external analysis */
+#define HASH_SIGNATURE 0xa0111fe1u
+#define HASH_BLOOM_SIGNATURE 0xb12220f2u
+
+typedef struct UT_hash_table {
+   UT_hash_bucket *buckets;
+   unsigned num_buckets, log2_num_buckets;
+   unsigned num_items;
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+
+   /* in an ideal situation (all buckets used equally), no bucket would have
+    * more than ceil(#items/#buckets) items. that's the ideal chain length. */
+   unsigned ideal_chain_maxlen;
+
+   /* nonideal_items is the number of items in the hash whose chain position
+    * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
+    * hash distribution; reaching them in a chain traversal takes >ideal steps */
+   unsigned nonideal_items;
+
+   /* ineffective expands occur when a bucket doubling was performed, but
+    * afterward, more than half the items in the hash had nonideal chain
+    * positions. If this happens on two consecutive expansions we inhibit any
+    * further expansion, as it's not helping; this happens when the hash
+    * function isn't a good fit for the key domain. When expansion is inhibited
+    * the hash will still work, albeit no longer in constant time. */
+   unsigned ineff_expands, noexpand;
+
+   uint32_t signature; /* used only to find hash tables in external analysis */
+#ifdef HASH_BLOOM
+   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+   uint8_t *bloom_bv;
+   uint8_t bloom_nbits;
+#endif
+
+} UT_hash_table;
+
+typedef struct UT_hash_handle {
+   struct UT_hash_table *tbl;
+   void *prev;                       /* prev element in app order      */
+   void *next;                       /* next element in app order      */
+   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
+   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
+   void *key;                        /* ptr to enclosing struct's key  */
+   unsigned keylen;                  /* enclosing struct's key len     */
+   unsigned hashv;                   /* result of hash-fcn(key)        */
+} UT_hash_handle;
+
+#endif /* UTHASH_H */

--- a/loom/engine/bindings/loom/lmApplicationTasks.cpp
+++ b/loom/engine/bindings/loom/lmApplicationTasks.cpp
@@ -21,6 +21,7 @@
 #include "loom/common/platform/platformTime.h"
 #include "loom/common/platform/platformHttp.h"
 #include "loom/common/platform/platformThread.h"
+#include "loom/common/platform/platformNetwork.h"
 #include "loom/common/core/performance.h"
 #include "loom/common/assets/assets.h"
 #include "loom/script/native/lsNativeDelegate.h"
@@ -28,7 +29,6 @@
 #include "loom/common/config/applicationConfig.h"
 #include "loom/engine/loom2d/l2dStage.h"
 #include "loom/graphics/gfxTexture.h"
-#include "loom/common/core/telemetry.h"
 
 lmDefineLogGroup(gTickLogGroup, "tick", true, LoomLogInfo)
 
@@ -59,8 +59,6 @@ void loom_tick()
 
     atomic_store32(&gLoomPaused, 0);
 
-    Telemetry::beginTick();
-    
     LOOM_PROFILE_START(loom_tick);
 
     LSLuaState *vm = NULL;
@@ -97,6 +95,7 @@ void loom_tick()
     }
     
     loom_asset_pump();
+    loom_net_pump();
     
     platform_HTTPUpdate();
     
@@ -107,10 +106,6 @@ void loom_tick()
     finishProfilerBlock(&p);
     
     LOOM_PROFILE_END(loom_tick);
-    
-    LOOM_PROFILE_ZERO_CHECK()
-    
-    Telemetry::endTick();
 
 }
 }

--- a/loom/graphics/gfxTexture.cpp
+++ b/loom/graphics/gfxTexture.cpp
@@ -513,7 +513,7 @@ void Texture::upload(TextureInfo &tinfo, uint8_t *data, uint16_t width, uint16_t
             mipLevel++;
         }
         lmLogDebug(gGFXTextureLogGroup, "Generated mipmaps in %d ms", platform_getMilliseconds() - time);
-        if (mipData != (uint32_t*)data) lmSafeFree(NULL, mipData);
+        if (mipData) lmSafeFree(NULL, mipData);
         LOOM_PROFILE_END(textureLoadMipmap);
     }
     else

--- a/loom/graphics/gfxTexture.cpp
+++ b/loom/graphics/gfxTexture.cpp
@@ -480,9 +480,12 @@ void Texture::upload(TextureInfo &tinfo, uint8_t *data, uint16_t width, uint16_t
 
             // Allocate buffer if it doesn't exist yet, reuse for smaller mipmaps
             if (mipData == NULL) {
+                int mipHalfWidth = mipWidth >> 1; mipHalfWidth = mipHalfWidth < 1 ? 1 : mipHalfWidth;
+                int mipHalfHeight = mipHeight >> 1; mipHalfHeight = mipHalfHeight < 1 ? 1 : mipHalfHeight;
+                int mipQuarterSize = mipHalfWidth*mipHalfHeight;
                 // Allocate enough for the biggest/current mipmap and a quarter of the size of
                 // additional space used for downsizing
-                mipData = static_cast<uint32_t*>(lmAlloc(NULL, mipSize * (4 + 1)));
+                mipData = static_cast<uint32_t*>(lmAlloc(NULL, (mipSize + mipQuarterSize)*sizeof(uint32_t)));
                 // The current mipmap bytes are the entire buffer minus the additional space
                 // at first, with the parent bytes being the full image size
                 mipCurrent = mipData;

--- a/loom/script/native/core/system/Platform/lmPlatform.cpp
+++ b/loom/script/native/core/system/Platform/lmPlatform.cpp
@@ -79,7 +79,7 @@ public:
 
     static bool openURL(const char *url)
     {
-        return platform_openURL(url);
+        return platform_openURL(url) == 0 ? false : true;
     }
 };
 

--- a/loom/script/native/core/system/lmJSON.cpp
+++ b/loom/script/native/core/system/lmJSON.cpp
@@ -48,9 +48,9 @@ static int registerSystemJSON(lua_State *L)
        .addMethod("setString", &JSON::setString)
        .addMethod("getBoolean", &JSON::getBoolean)
        .addMethod("setBoolean", &JSON::setBoolean)
-       .addMethod("getObject", &JSON::getObject)
+       .addMethod("getObject", &JSON::getObjectNew)
        .addMethod("setObject", &JSON::setObject)
-       .addMethod("getArray", &JSON::getArray)
+       .addMethod("getArray", &JSON::getArrayNew)
        .addMethod("setArray", &JSON::setArray)
 
        .addMethod("isObject", &JSON::isObject)
@@ -75,10 +75,10 @@ static int registerSystemJSON(lua_State *L)
        .addMethod("getArrayString", &JSON::getArrayString)
        .addMethod("setArrayString", &JSON::setArrayString)
 
-       .addMethod("getArrayObject", &JSON::getArrayObject)
+       .addMethod("getArrayObject", &JSON::getArrayObjectNew)
        .addMethod("setArrayObject", &JSON::setArrayObject)
 
-       .addMethod("getArrayArray", &JSON::getArrayArray)
+       .addMethod("getArrayArray", &JSON::getArrayArrayNew)
        .addMethod("setArrayArray", &JSON::setArrayArray)
 
 

--- a/loom/script/native/core/system/lmString.cpp
+++ b/loom/script/native/core/system/lmString.cpp
@@ -63,10 +63,11 @@ public:
     {
         lmAssert(lua_isstring(L, 1), "Non-string passed to String._charAt");
 
-        const char *svalue = lua_tostring(L, 1);
+        size_t length;
+        const char *svalue = lua_tolstring(L, 1, &length);
         int        index   = (int)lua_tonumber(L, 2);
 
-        if (!svalue || !svalue[0] || (index < 0) || (index >= (int)strlen(svalue)))
+        if (!svalue || !svalue[0] || (index < 0) || ((size_t)index >= length))
         {
             lua_pushstring(L, "");
             return 1;
@@ -115,7 +116,8 @@ public:
 
     static int _length(lua_State *L)
     {
-        const char *svalue = lua_tostring(L, 1);
+        size_t length;
+        const char *svalue = lua_tolstring(L, 1, &length);
 
         if (!svalue)
         {
@@ -123,7 +125,7 @@ public:
         }
         else
         {
-            lua_pushnumber(L, (lua_Number)strlen(svalue));
+            lua_pushnumber(L, (lua_Number)length);
         }
         return 1;
     }

--- a/loom/script/reflection/lsMemberInfo.h
+++ b/loom/script/reflection/lsMemberInfo.h
@@ -534,7 +534,7 @@ public:
      */
     inline const char *getFullMemberName()
     {
-        lmAssert(fullMemberName.size(), "fullMemberName not set");
+        lmAssert(fullMemberName != "", "fullMemberName not set");
         return fullMemberName.c_str();
     }
 };

--- a/loom/script/reflection/lsMethodInfo.h
+++ b/loom/script/reflection/lsMethodInfo.h
@@ -26,6 +26,8 @@
 #include "loom/script/reflection/lsReflection.h"
 #include "loom/script/reflection/lsType.h"
 
+struct LoomProfilerRoot;
+
 namespace LS {
 struct MethodAttributes : BaseAttributes
 {
@@ -131,11 +133,13 @@ private:
 
 protected:
 
-    MethodBase() : byteCode(NULL), cfunction(NULL), propertyInfo(NULL), firstDefaultArg(-1), varArgIndex(-2)
+    MethodBase() : byteCode(NULL), cfunction(NULL), propertyInfo(NULL), firstDefaultArg(-1), varArgIndex(-2), profilerRoot(NULL)
     {
     }
 
 public:
+
+    LoomProfilerRoot *profilerRoot;
 
     ~MethodBase()
     {

--- a/loom/script/runtime/lsProfiler.cpp
+++ b/loom/script/runtime/lsProfiler.cpp
@@ -37,15 +37,16 @@ utHashTable<utPointerHashKey, MethodAllocation> *LSProfiler::sortMethods = NULL;
 
 lmDefineLogGroup(gProfilerLogGroup, "profiler", 1, LoomLogInfo);
 
+static const char* primingPath = ".......";
+
 static inline void primeProfiler()
 {
-    const char       *path = ".......";
-    LoomProfilerRoot **prd = dynamicProfilerRoots[path];
+    LoomProfilerRoot **prd = dynamicProfilerRoots[primingPath];
 
     if (prd == NULL)
     {
-        dynamicProfilerRoots.insert(path, new LoomProfilerRoot(strdup(path)));
-        prd = dynamicProfilerRoots[path];
+        dynamicProfilerRoots.insert(primingPath, lmNew(NULL) LoomProfilerRoot(primingPath));
+        prd = dynamicProfilerRoots[primingPath];
     }
 
     gLoomProfiler->hashPush(*prd);
@@ -246,6 +247,7 @@ void LSProfiler::updateState(lua_State *L) {
     primeProfiler();
 
     methodStack.clear();
+    methodStack.reserve(128);
     clearAllocations();
 
     if (enabled)
@@ -259,7 +261,7 @@ void LSProfiler::updateState(lua_State *L) {
             if (!shouldFilterFunction(stack.peek(0)->getFullMemberName()))
             {
                 methodStack.push(stack.peek(0));
-                enterMethod(stack.peek(0)->getFullMemberName());
+                enterMethod(stack.peek(0));
             }
 
             stack.pop();
@@ -274,7 +276,7 @@ void LSProfiler::updateState(lua_State *L) {
 }
 
 
-void LSProfiler::enterMethod(const char *fullPath)
+void LSProfiler::enterMethod(MethodBase* method)
 {
     if (!isEnabled())
     {
@@ -283,29 +285,24 @@ void LSProfiler::enterMethod(const char *fullPath)
 
     //printf("Entering %s\n", fullPath);
 
-    LoomProfilerRoot **prd = dynamicProfilerRoots[fullPath];
-    if (prd == NULL)
+    if (method->profilerRoot == NULL)
     {
-        dynamicProfilerRoots.insert(fullPath, new LoomProfilerRoot(strdup(fullPath)));
-        prd = dynamicProfilerRoots[fullPath];
+        method->profilerRoot = LoomProfilerRoot::fromName(method->getFullMemberName());
     }
 
-    gLoomProfiler->hashPush(*prd);
+    gLoomProfiler->hashPush(method->profilerRoot);
 }
 
 
-void LSProfiler::leaveMethod(const char *fullPath)
+void LSProfiler::leaveMethod(MethodBase* method)
 {
     if (!isEnabled())
     {
         return;
     }
 
-    //printf("Leaving %s\n", fullPath);
-
-    LoomProfilerRoot **prd = dynamicProfilerRoots[fullPath];
-    lmAssert(prd, "Should never leave a method we didn't enter first!");
-    gLoomProfiler->hashPop(*prd);
+    lmAssert(method->profilerRoot, "Should never leave a method we didn't enter first!");
+    gLoomProfiler->hashPop(method->profilerRoot);
 }
 
 
@@ -330,7 +327,7 @@ void LSProfiler::profileHook(lua_State *L, lua_Debug *ar)
         if (methodBase)
         {
             methodStack.push(methodBase);
-            enterMethod(methodBase->getFullMemberName());
+            enterMethod(methodBase);
         }
     }
 
@@ -343,7 +340,7 @@ void LSProfiler::profileHook(lua_State *L, lua_Debug *ar)
             if (methodStack.size())
             {
                 methodStack.pop();
-                leaveMethod(methodBase->getFullMemberName());
+                leaveMethod(methodBase);
             }
         }
     }
@@ -356,7 +353,7 @@ void LSProfiler::dump(lua_State *L)
 
     while (methodStack.size())
     {
-        leaveMethod(methodStack.peek(0)->getFullMemberName());
+        leaveMethod(methodStack.peek(0));
         methodStack.pop();
     }
 

--- a/loom/script/runtime/lsProfiler.h
+++ b/loom/script/runtime/lsProfiler.h
@@ -26,6 +26,9 @@
 #include "loom/script/loomscript.h"
 
 namespace LS {
+
+class MethodBase;
+
 struct LSProfilerTypeAllocation
 {
     Type                               *type;
@@ -54,8 +57,8 @@ typedef struct MethodAllocation {
 class LSProfiler
 {
 private:
-    static void enterMethod(const char *fullPath);
-    static void leaveMethod(const char *fullPath);
+    static void enterMethod(MethodBase *method);
+    static void leaveMethod(MethodBase *method);
 
     static void profileHook(lua_State *L, lua_Debug *ar);
 

--- a/sdk/src/system/ByteArray.ls
+++ b/sdk/src/system/ByteArray.ls
@@ -61,7 +61,7 @@ package system
     /**
      *  Clears the contents of the byte array and resets the length and position properties to 0.
      */
-    public native function clear():void;
+    public native function clear(useCache:Boolean = false):void;
     
     /**
      *  Reserves the number of bytes specified.

--- a/tools/assetAgent/include/telemetryServer.h
+++ b/tools/assetAgent/include/telemetryServer.h
@@ -14,10 +14,10 @@ public:
 
     JSON tickValuesJSON;
     JSON tickRangesJSON;
-    JSON tickMetricsJSON;
+    JSON tickRangeMetaJSON;
 
     // The main JSON string already serialized and ready for transmission
-    static utString tickMetricsJSONString;
+    static utByteArray tickMetricsJSONBytes;
 
     void updateMetricsJSON();
 };
@@ -50,8 +50,9 @@ public:
     // Returns true if the server is running, otherwise false
     static bool isRunning();
 
-    // Send the provided message to all the connected clients
-    static void sendAll(const char* msg);
+    // Send the provided message to all the connected clients. Length is
+    // `strlen(msg)` by default.
+    static void sendAll(const char* msg, size_t len = -1);
 };
 
 

--- a/tools/assetAgent/src/main.cpp
+++ b/tools/assetAgent/src/main.cpp
@@ -756,22 +756,22 @@ static int socketListeningThread(void *payload)
         {
             // Process the connections.
             loom_mutex_lock(gActiveSocketsMutex);
-			
+            
             for (UTsize i = 0; i < gActiveHandlers.size(); i++)
             {
-				AssetProtocolHandler* aph = gActiveHandlers[i];
+                AssetProtocolHandler* aph = gActiveHandlers[i];
                 aph->process();
 
                 // Check for ping timeout
-				int msSincePing = loom_readTimer(aph->lastActiveTime);
-				if (msSincePing > socketPingTimeoutMs)
-				{
-					gActiveHandlers.erase(i);
-					i--;
-					lmLog(gAssetAgentLogGroup, "Client timed out (%x)", aph->socket);
-					loom_net_closeTCPSocket(aph->socket);
-					lmDelete(NULL, aph);
-				}
+                int msSincePing = loom_readTimer(aph->lastActiveTime);
+                if (msSincePing > socketPingTimeoutMs)
+                {
+                    gActiveHandlers.erase(i);
+                    i--;
+                    lmLog(gAssetAgentLogGroup, "Client timed out (%x)", aph->socket);
+                    loom_net_closeTCPSocket(aph->socket);
+                    lmDelete(NULL, aph);
+                }
             }
 
             loom_mutex_unlock(gActiveSocketsMutex);
@@ -934,7 +934,7 @@ void DLLEXPORT assetAgent_run(IdleCallback idleCb, LogCallback logCb, FileChange
             lmDelete(NULL, cqn);
         }
         // Pump any remaining socket writes
-		loom_net_pump();
+        loom_net_pump();
 
         // Poll at about 60hz.
         loom_thread_sleep(16);

--- a/tools/assetAgent/src/telemetryServer.cpp
+++ b/tools/assetAgent/src/telemetryServer.cpp
@@ -258,7 +258,6 @@ bool TelemetryListener::handleMessage(int fourcc, AssetProtocolHandler *handler,
         buffer.attach((char*)netBuffer.buffer + curPos, netBuffer.length - curPos);
 
         TableValues<TickMetricValue> tickValues;
-        TableValues<TickMetricRange> tickRanges;
 
         loom_mutex_lock(jsonMutex);
 

--- a/tools/assetAgent/src/telemetryServer.cpp
+++ b/tools/assetAgent/src/telemetryServer.cpp
@@ -17,13 +17,15 @@ lmDefineLogGroup(gTelemetryServerLogGroup, "lts", true, LoomLogInfo)
 // Server might be multithreaded, so lock our data to be sure
 static MutexHandle jsonMutex = loom_mutex_create();
 
-// This holds the current tick as a serialized json string ready to be sent
-utString TelemetryListener::tickMetricsJSONString;
+// This holds the current tick as serialized json string bytes ready to be sent
+utByteArray TelemetryListener::tickMetricsJSONBytes;
 
 mg_callbacks TelemetryServer::callbacks;
 mg_context* TelemetryServer::server = NULL;
 utString TelemetryServer::clientRoot;
 
+static const char* failJSON = "{ \"status\": \"fail\", \"data\": null }";
+static size_t failJSONSize = strlen(failJSON);
 
 // Used to assign clients a unique id
 static int clientGlobalID = 0;
@@ -123,13 +125,13 @@ void StreamCloseHandler(const struct mg_connection * conn, void *cbdata)
 }
 
 // Send the provided message to all connected clients
-void StreamSendAll(struct mg_context *ctx, const char *msg)
+void StreamSendAll(struct mg_context *ctx, const char *msg, size_t len = -1)
 {
     int i;
     mg_lock_context(ctx);
     for (i = 0; i < LTS_MAX_CLIENTS; i++) {
         if (streamClients[i].state == 2) {
-            mg_websocket_write(streamClients[i].conn, WEBSOCKET_OPCODE_TEXT, msg, strlen(msg));
+            mg_websocket_write(streamClients[i].conn, WEBSOCKET_OPCODE_TEXT, msg, len == -1 ? strlen(msg) : len);
         }
     }
     mg_unlock_context(ctx);
@@ -137,36 +139,50 @@ void StreamSendAll(struct mg_context *ctx, const char *msg)
 
 
 
-// Replies with the provided custom data JSON (or replies with failure status on invalid JSON serialization)
-static int JSONHandler(struct mg_connection *conn, void *cbdata)
-{
-    JSON* json = (JSON*)cbdata;
-    lmAssert(json != NULL, "Invalid JSON object provided to the JSON handler");
-    loom_mutex_lock(jsonMutex);
-    const char* serialized = json->serialize();
-    if (serialized == NULL)
-    {
-        serialized = "{ \"status\": \"fail\", \"data\": null }";
-    }
-    mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n");
-    mg_write(conn, serialized, strlen(serialized));
-    loom_mutex_unlock(jsonMutex);
-    return 1;
-}
-
 // Replies with the provided custom data JSON string (or replies with failure status if the string is empty)
 static int JSONStringHandler(struct mg_connection *conn, void *cbdata)
 {
     utString* jsonString = (utString*)cbdata;
+    const char* buf;
+    size_t len;
     lmAssert(jsonString != NULL, "Invalid JSON object provided to the JSON handler");
     loom_mutex_lock(jsonMutex);
-    if (jsonString->empty())
+    if (!jsonString->empty())
     {
-        utString fail = utString("{ \"status\": \"fail\", \"data\": null }");
-        jsonString = &fail;
+        buf = jsonString->c_str();
+        len = jsonString->length();
+    }
+    else
+    {
+        buf = failJSON;
+        len = failJSONSize;
     }
     mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n");
-    mg_write(conn, jsonString->c_str(), jsonString->length());
+    mg_write(conn, buf, len);
+    loom_mutex_unlock(jsonMutex);
+    return 1;
+}
+
+// Replies with the provided custom data JSON bytes (or replies with failure status if the bytes are empty)
+static int JSONBytesHandler(struct mg_connection *conn, void *cbdata)
+{
+    utByteArray* jsonBytes = (utByteArray*)cbdata;
+    const char* buf;
+    size_t len;
+    lmAssert(jsonBytes != NULL, "Invalid JSON object provided to the JSON handler");
+    loom_mutex_lock(jsonMutex);
+    if (jsonBytes->getSize() > 0)
+    {
+        buf = reinterpret_cast<const char*>(jsonBytes->getDataPtr());
+        len = jsonBytes->getSize();
+    }
+    else
+    {
+        buf = failJSON;
+        len = failJSONSize;
+    }
+    mg_printf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n");
+    mg_write(conn, buf, len);
     loom_mutex_unlock(jsonMutex);
     return 1;
 }
@@ -186,7 +202,7 @@ void TelemetryServer::start()
     server = mg_start(&callbacks, NULL, options);
 
     // Set /tick as a handler that returns the main JSON string
-    mg_set_request_handler(server, LTS_TICK_URI, JSONStringHandler, &TelemetryListener::tickMetricsJSONString);
+    mg_set_request_handler(server, LTS_TICK_URI, JSONBytesHandler, &TelemetryListener::tickMetricsJSONBytes);
 
     // Set /stream as the websocket connection that streams all the ticks
     mg_set_websocket_handler(server, LTS_STREAM_URI, StreamConnectHandler, StreamReadyHandler, StreamDataHandler, StreamCloseHandler, NULL);
@@ -210,11 +226,11 @@ bool TelemetryServer::isRunning()
     return server != NULL;
 }
 
-void TelemetryServer::sendAll(const char *msg)
+void TelemetryServer::sendAll(const char *msg, size_t len)
 {
     if (server == NULL) return;
 
-    StreamSendAll(server, msg);
+    StreamSendAll(server, msg, len);
 }
 
 void TelemetryServer::setClientRootFromSDK(const char *root)
@@ -246,16 +262,15 @@ bool TelemetryListener::handleMessage(int fourcc, AssetProtocolHandler *handler,
 
         loom_mutex_lock(jsonMutex);
 
+        // Read the tick profiler events and roots first
+        Telemetry::readTickProfiler(buffer, tickRangesJSON, tickRangeMetaJSON);
+
         while (buffer.bytesAvailable() > 0)
         {
             // Try reading tables in succession (each table knows how to read itself and returns false if it can't)
             if (tickValues.read(&buffer))
             {
                 tickValues.writeJSONObject(&tickValuesJSON);
-            }
-            else if (tickRanges.read(&buffer))
-            {
-                tickRanges.writeJSONArray(&tickRangesJSON);
             }
             else
             {
@@ -282,18 +297,22 @@ void TelemetryListener::updateMetricsJSON()
 {
     JSON jdata;
 
+    JSON tickMetricsJSON;
     tickMetricsJSON.initObject();
     tickMetricsJSON.setString("status", "success");
 
+    // Put together metrics data JSON
     jdata.initObject();
     jdata.setObject("values", &tickValuesJSON);
     jdata.setArray("ranges", &tickRangesJSON);
+    jdata.setObject("rangeInfo", &tickRangeMetaJSON);
     tickMetricsJSON.setObject("data", &jdata);
 
-    const char *serialized = tickMetricsJSON.serialize();
-    tickMetricsJSONString = serialized;
-    lmFree(NULL, (void*)serialized);
+    // Write tick metrics JSON to the byte array
+    tickMetricsJSONBytes.clear(true);
+    tickMetricsJSON.serializeToBuffer(&tickMetricsJSONBytes);
+    tickMetricsJSONBytes.resize(tickMetricsJSONBytes.getPosition());
 
     // Send the newly serialized json to all clients automatically
-    TelemetryServer::sendAll(tickMetricsJSONString.c_str());
+    TelemetryServer::sendAll(static_cast<const char*>(tickMetricsJSONBytes.getDataPtr()), tickMetricsJSONBytes.getSize());
 }


### PR DESCRIPTION
1. Telemetry now covers more things, notably the (SDL) event loop.
2. Added support for unsigned 64bit integers to NetworkBuffer.
3. Better buffer usage in AssetProtocolHandler.
4. AssetProtocolHandlers can now be freed properly.
5. loom_newArray allocation now skips constructors for fundamental types.
6. Telemetry now uses an event-and-lookup design, which is a bit tougher on bandwidth, but much lower on processing. The bandwidth issue is side-stepped with new buffered network writes.
7. Network writes are now buffered in a bip buffer. This avoids stalls and blocking.
8. The asset agent connection is now more aware of issues on both ends, reads and writes now time out after some time and the connection is dropped.
9. Changed from double to long long in readTimerNano to avoid unnecessary FP ops.
10. Fixed some JSON leaks and simplified implementation / memory management wrt usage a bit.
11. Added a `useCache` parameter to `utByteArray` to expose the underlying `utArray` cache.
12. Added `utByteArray` reading/writing unsigned 64-bit ints.
13. Added temp fix for reading/writing unaligned `utByteArray` strings.
14. Added uthash, a simple hash table for use from C code.
15. Added `utString::alloc` to provide a way to reserve a string buffer in advance.
16. Added an unsigned 64-bit int hash key support to `utHashTable`.
17. Changed some SQLite code to use the newer JSON APIs that manage memory automatically.
18. Fixed texture mipmapping code to actually allocate properly.
19. Fixed some internal string functions to use the lua string length and not recompute all the time with strlen, noticable with larger strings.
20. Fixed a bool warning for `openURL`.
21. Made a `MemberInfo` check function faster by avoiding string length computation.
22. Added `LoomProfilerRoot` to `MethodBase` to support the new telemetry system.
23. Fixed some telemetry server memory leaks.
24. Added a ping timeout to the asset agent connection.
25. Added support for multiple "root" tick ranges to the telemetry client.
26. Added display of write/read overhead to telemetry client.